### PR TITLE
Provide `index` for the item templates

### DIFF
--- a/example/app.tsx
+++ b/example/app.tsx
@@ -21,6 +21,9 @@ import ToolbarExample from "./toolbar-example";
 import ValidationExample from "./validation-example";
 
 import { Button, NumberBox } from "../src";
+import config from "../src/core/config";
+
+config({ useLegacyTemplateEngine: false });
 
 ReactDOM.render(
   <div>

--- a/example/data-grid-example.tsx
+++ b/example/data-grid-example.tsx
@@ -17,11 +17,11 @@ import NumberBox from "../src/number-box";
 
 import { sales } from "./data";
 
-const DetailComponent = (props: any) => {
+const DetailComponent = ({ data: { data } }: any) => {
     return (
         <p>Row data:
             <br/>
-            {JSON.stringify(props.data.data)}
+            {JSON.stringify(data)}
         </p>
     );
 };

--- a/example/data-grid-example.tsx
+++ b/example/data-grid-example.tsx
@@ -21,17 +21,17 @@ const DetailComponent = (props: any) => {
     return (
         <p>Row data:
             <br/>
-            {JSON.stringify(props.data)}
+            {JSON.stringify(props.data.data)}
         </p>
     );
 };
 
 const CityComponent = (props: any) => {
-    return <i>{props.displayValue}</i>;
+    return <i>{props.data.displayValue}</i>;
 };
 
 const RegionComponent = (props: any) => {
-    return <b>{props.displayValue}</b>;
+    return <b>{props.data.displayValue}</b>;
 };
 
 export default class extends React.Component<any, { expandAll: boolean, pageSize: number }> {

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -9,7 +9,10 @@ import TextBox from "../src/text-box";
 import Example from "./example-block";
 
 interface IListItemProps {
-    text: string;
+    data: {
+        text: string;
+    };
+    index: number;
 }
 
 class Item extends React.Component<IListItemProps, { counter: number }> {
@@ -26,7 +29,8 @@ class Item extends React.Component<IListItemProps, { counter: number }> {
     public render() {
         return (
             <i onClick={this.handleClick}>
-                Component template for item {this.props.text}. <b>Clicks: {this.state.counter}</b>
+                {this.props.index + 1}. Component template for item {this.props.data.text}.
+                <b>Clicks: {this.state.counter}</b>
             </i>
         );
     }

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -27,9 +27,10 @@ class Item extends React.Component<IListItemProps, { counter: number }> {
     }
 
     public render() {
+        const { data: { text }, index } = this.props;
         return (
             <i onClick={this.handleClick}>
-                {this.props.index + 1}. Component template for item {this.props.data.text}.
+                {index + 1}. Component template for item {text}.
                 <b>Clicks: {this.state.counter}</b>
             </i>
         );

--- a/example/scheduler-example.tsx
+++ b/example/scheduler-example.tsx
@@ -7,7 +7,7 @@ import { appointments } from "./data";
 
 class DateCell extends React.PureComponent<any> {
     public render() {
-        const now = this.props.date;
+        const now = this.props.data.date;
         const start = new Date(now.getFullYear(), 0, 0).getTime();
         const dayNumber = Math.floor((now - start) / (1000 * 60 * 60 * 24));
         return (

--- a/example/scheduler-example.tsx
+++ b/example/scheduler-example.tsx
@@ -7,12 +7,12 @@ import { appointments } from "./data";
 
 class DateCell extends React.PureComponent<any> {
     public render() {
-        const now = this.props.data.date;
+        const { date: now, text } = this.props.data;
         const start = new Date(now.getFullYear(), 0, 0).getTime();
         const dayNumber = Math.floor((now - start) / (1000 * 60 * 60 * 24));
         return (
             <div style={{ height: "50px", color: now.getDay() % 6 === 0 ? "red" : "" }}>
-                <h4>{this.props.text}</h4>
+                <h4>{text}</h4>
                 <h5>{dayNumber}</h5>
             </div>
         );

--- a/src/core/__tests__/config.test.tsx
+++ b/src/core/__tests__/config.test.tsx
@@ -15,18 +15,18 @@ class ComponentWithTemplates extends TestComponent {
     }
 }
 
-describe("useLegacyTemplatEngine", () => {
-    const originalValue = getOption("useLegacyTemplatEngine");
+describe("useLegacyTemplateEngine", () => {
+    const originalValue = getOption("useLegacyTemplateEngine");
 
     beforeEach(() => {
-        config({ useLegacyTemplatEngine: true });
+        config({ useLegacyTemplateEngine: true });
     });
 
     afterEach(() => {
-        config({ useLegacyTemplatEngine: originalValue });
+        config({ useLegacyTemplateEngine: originalValue });
     });
 
-    it("works for render template", () => {
+    it("works for render-function template", () => {
         const ItemTemplate = (data: any) => (
             <div className={"template"}>
                 value: {data.value}, key: {data.key}, dxkey: {data.dxkey}

--- a/src/core/__tests__/config.test.tsx
+++ b/src/core/__tests__/config.test.tsx
@@ -1,0 +1,70 @@
+import config from "../../core/config";
+import { mount, React} from "./setup";
+import { TestComponent, WidgetClass } from "./test-component";
+
+class ComponentWithTemplates extends TestComponent {
+    protected _templateProps = [{
+        tmplOption: "item",
+        render: "itemRender",
+        component: "itemComponent",
+        keyFn: "itemKeyFn"
+    }];
+
+    constructor(props: any) {
+        super(props);
+    }
+}
+
+describe("useLegacyTemplatEngine", () => {
+    beforeEach(() => {
+        config({ useLegacyTemplatEngine: true });
+    });
+
+    afterEach(() => {
+        config({ useLegacyTemplatEngine: false });
+    });
+
+    it("works for render template", () => {
+        const ItemTemplate = (data: any) => (
+            <div className={"template"}>
+                value: {data.value}, key: {data.key}, dxkey: {data.dxkey}
+            </div>
+        );
+
+        const component = mount(
+            <ComponentWithTemplates itemRender={ItemTemplate} />
+        );
+
+        const render = WidgetClass.mock.calls[0][1].integrationOptions.templates.item.render;
+
+        render({
+            container: document.createElement("div"),
+            model: { value: "Value", key: "key_1" }
+        });
+
+        component.update();
+        expect(component.find(".template").text()).toBe("value: Value, key: key_1, dxkey: key_1");
+    });
+
+    it("works for component template", () => {
+        const ItemTemplate = (props: any) => (
+            <div className={"template"}>
+                value: {props.value}, key: {props.key}, dxkey: {props.dxkey}
+            </div>
+        );
+
+        const component = mount(
+            <ComponentWithTemplates itemComponent={ItemTemplate} />
+        );
+
+        const render = WidgetClass.mock.calls[0][1].integrationOptions.templates.item.render;
+
+        render({
+            container: document.createElement("div"),
+            model: { value: "Value", key: "key_1" }
+        });
+
+        component.update();
+        expect(component.find(".template").text()).toBe("value: Value, key: , dxkey: key_1");
+    });
+});

--- a/src/core/__tests__/config.test.tsx
+++ b/src/core/__tests__/config.test.tsx
@@ -1,4 +1,4 @@
-import config from "../../core/config";
+import config, { getOption } from "../../core/config";
 import { mount, React} from "./setup";
 import { TestComponent, WidgetClass } from "./test-component";
 
@@ -16,12 +16,14 @@ class ComponentWithTemplates extends TestComponent {
 }
 
 describe("useLegacyTemplatEngine", () => {
+    const originalValue = getOption("useLegacyTemplatEngine");
+
     beforeEach(() => {
         config({ useLegacyTemplatEngine: true });
     });
 
     afterEach(() => {
-        config({ useLegacyTemplatEngine: false });
+        config({ useLegacyTemplatEngine: originalValue });
     });
 
     it("works for render template", () => {

--- a/src/core/__tests__/template.test.tsx
+++ b/src/core/__tests__/template.test.tsx
@@ -1,9 +1,20 @@
 import * as events from "devextreme/events";
 
+import config, { getOption as getConfigOption } from "../../core/config";
 import ConfigurationComponent from "../../core/nested-option";
 import { Template } from "../../core/template";
 import { mount, React, shallow } from "./setup";
 import { TestComponent, Widget, WidgetClass } from "./test-component";
+
+const originalLegacyOption = getConfigOption("useLegacyTemplatEngine");
+
+beforeEach(() => {
+    config({ useLegacyTemplatEngine: false });
+});
+
+afterEach(() => {
+    config({ useLegacyTemplatEngine: originalLegacyOption });
+});
 
 // tslint:disable-next-line:max-classes-per-file
 class ComponentWithTemplates extends TestComponent {

--- a/src/core/__tests__/template.test.tsx
+++ b/src/core/__tests__/template.test.tsx
@@ -283,19 +283,6 @@ describe("function template", () => {
 describe("component template", () => {
     testTemplateOption("itemComponent");
 
-    it("renders key prop", () => {
-        const ItemTemplate = (props: any) => (
-            <div className={"template"}>key: {props.data.key}, dxkey: {props.data.dxkey}</div>
-        );
-        const component = mount(
-            <ComponentWithTemplates itemComponent={ItemTemplate} />
-        );
-
-        renderItemTemplate({ key: "key_1" }, undefined, 5);
-        component.update();
-        expect(component.find(".template").html()).toBe('<div class="template">key: key_1, dxkey: key_1</div>');
-    });
-
     it("renders index", () => {
         const ItemTemplate = (props: any) => (
             <div className={"template"}>

--- a/src/core/__tests__/template.test.tsx
+++ b/src/core/__tests__/template.test.tsx
@@ -35,6 +35,21 @@ function renderItemTemplate(model?: any, container?: any, index?: number, onRend
 }
 
 function testTemplateOption(testedOption: string) {
+    let prepareTemplate = (render) => render;
+
+    if (testedOption === "itemComponent") {
+        prepareTemplate = (render) => {
+            // tslint:disable-next-line:max-classes-per-file
+            class ItemComponent extends React.PureComponent {
+                public props: { data: any, index?: number };
+                public render() {
+                    return render(this.props.data, this.props.index);
+                }
+            }
+            return ItemComponent;
+        };
+    }
+
     it("pass integrationOptions to widget", () => {
         const elementOptions: Record<string, any> = {};
         elementOptions[testedOption] = () => <div>Template</div>;
@@ -54,7 +69,9 @@ function testTemplateOption(testedOption: string) {
 
     it("renders", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <div className={"template"}>Template {props.text}</div>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => (
+            <div className={"template"}>Template {data.text}</div>
+        ));
 
         const component = mount(React.createElement(ComponentWithTemplates, elementOptions));
 
@@ -129,7 +146,7 @@ function testTemplateOption(testedOption: string) {
 
     it("renders template removeEvent listener", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <div>Template {props.text}</div>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => <div>Template {data.text}</div>);
         const component = mount(React.createElement(ComponentWithTemplates, elementOptions));
 
         const container = document.createElement("div");
@@ -140,7 +157,9 @@ function testTemplateOption(testedOption: string) {
 
     it("renders template removeEvent listener for table", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <tbody><tr><td>Template {props.text}</td></tr></tbody>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => (
+            <tbody><tr><td>Template {data.text}</td></tr></tbody>
+        ));
         const component = mount(React.createElement(ComponentWithTemplates, elementOptions));
 
         const container = document.createElement("table");
@@ -153,7 +172,9 @@ function testTemplateOption(testedOption: string) {
 
     it("calls onRendered callback", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <div className={"template"}>Template {props.text}</div>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => (
+            <div className={"template"}>Template {data.text}</div>
+        ));
         const component = mount(React.createElement(ComponentWithTemplates, elementOptions));
         const onRendered: () => void = jest.fn();
 
@@ -174,7 +195,9 @@ function testTemplateOption(testedOption: string) {
 
     it("has templates in state with unique ids", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <div className={"template"}>Template {props.text}</div>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => (
+            <div className={"template"}>Template {data.text}</div>
+        ));
         const component = shallow(React.createElement(ComponentWithTemplates, elementOptions));
 
         renderItemTemplate({ text: 1 });
@@ -187,7 +210,9 @@ function testTemplateOption(testedOption: string) {
 
     it("has templates in state with ids genetated with keyExpr", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <div className={"template"}>Template {props.text}</div>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => (
+            <div className={"template"}>Template {data.text}</div>
+        ));
         elementOptions.itemKeyFn = (data) => data.text;
         const component = shallow(React.createElement(ComponentWithTemplates, elementOptions));
 
@@ -202,7 +227,9 @@ function testTemplateOption(testedOption: string) {
 
     it("removes deleted nodes from state", () => {
         const elementOptions: Record<string, any> = {};
-        elementOptions[testedOption] = (props: any) => <div className={"template"}>Template {props.text}</div>;
+        elementOptions[testedOption] = prepareTemplate((data: any) => (
+            <div className={"template"}>Template {data.text}</div>
+        ));
         const component = mount(React.createElement(ComponentWithTemplates, elementOptions));
 
         renderItemTemplate();
@@ -257,14 +284,32 @@ describe("component template", () => {
     testTemplateOption("itemComponent");
 
     it("renders key prop", () => {
-        const ItemTemplate = (props: any) => <div className={"template"}>key: {props.key}, dxkey: {props.dxkey}</div>;
+        const ItemTemplate = (props: any) => (
+            <div className={"template"}>key: {props.data.key}, dxkey: {props.data.dxkey}</div>
+        );
         const component = mount(
             <ComponentWithTemplates itemComponent={ItemTemplate} />
         );
 
         renderItemTemplate({ key: "key_1" }, undefined, 5);
         component.update();
-        expect(component.find(".template").html()).toBe('<div class="template">key: , dxkey: key_1</div>');
+        expect(component.find(".template").html()).toBe('<div class="template">key: key_1, dxkey: key_1</div>');
+    });
+
+    it("renders index", () => {
+        const ItemTemplate = (props: any) => (
+            <div className={"template"}>
+                value: {props.data.value}, index: {props.index}
+            </div>
+        );
+
+        const component = mount(
+            <ComponentWithTemplates itemComponent={ItemTemplate} />
+        );
+
+        renderItemTemplate({ value: "Value" }, undefined, 5);
+        component.update();
+        expect(component.find(".template").text()).toBe("value: Value, index: 5");
     });
 });
 

--- a/src/core/__tests__/template.test.tsx
+++ b/src/core/__tests__/template.test.tsx
@@ -6,14 +6,14 @@ import { Template } from "../../core/template";
 import { mount, React, shallow } from "./setup";
 import { TestComponent, Widget, WidgetClass } from "./test-component";
 
-const originalLegacyOption = getConfigOption("useLegacyTemplatEngine");
+const originalLegacyOption = getConfigOption("useLegacyTemplateEngine");
 
 beforeEach(() => {
-    config({ useLegacyTemplatEngine: false });
+    config({ useLegacyTemplateEngine: false });
 });
 
 afterEach(() => {
-    config({ useLegacyTemplatEngine: originalLegacyOption });
+    config({ useLegacyTemplateEngine: originalLegacyOption });
 });
 
 // tslint:disable-next-line:max-classes-per-file

--- a/src/core/__tests__/template.test.tsx
+++ b/src/core/__tests__/template.test.tsx
@@ -20,18 +20,18 @@ class ComponentWithTemplates extends TestComponent {
     }
 }
 
-function renderTemplate(name: string, model?: any, container?: any, onRendered?: () => void): Element {
+function renderTemplate(name: string, model?: any, container?: any, index?: number, onRendered?: () => void): Element {
     model = model || {};
     container = container || document.createElement("div");
     const render = WidgetClass.mock.calls[0][1].integrationOptions.templates[name].render;
 
     return render({
-        container, model, onRendered
+        container, model, ...(index && { index }), onRendered
     });
 }
 
-function renderItemTemplate(model?: any, container?: any, onRendered?: () => void): Element {
-    return renderTemplate("item", model, container, onRendered);
+function renderItemTemplate(model?: any, container?: any, index?: number, onRendered?: () => void): Element {
+    return renderTemplate("item", model, container, index, onRendered);
 }
 
 function testTemplateOption(testedOption: string) {
@@ -157,7 +157,7 @@ function testTemplateOption(testedOption: string) {
         const component = mount(React.createElement(ComponentWithTemplates, elementOptions));
         const onRendered: () => void = jest.fn();
 
-        renderItemTemplate({ text: "with data" }, undefined, onRendered);
+        renderItemTemplate({ text: "with data" }, undefined, undefined, onRendered);
         component.update();
         jest.runAllTimers();
         expect(onRendered).toBeCalled();
@@ -237,6 +237,20 @@ describe("function template", () => {
         component.update();
         expect(component.find(".template").html()).toBe('<div class="template">Template with data</div>');
     });
+
+    it("renders index", () => {
+        const itemRender: any = jest.fn((_, index: number) => {
+            return <div className={"template"}>Index {index}</div>;
+        });
+        const component = mount(
+            <ComponentWithTemplates itemRender={itemRender} />
+        );
+        renderItemTemplate(undefined, undefined, 5);
+
+        expect(itemRender).toBeCalled();
+        component.update();
+        expect(component.find(".template").html()).toBe('<div class="template">Index 5</div>');
+    });
 });
 
 describe("component template", () => {
@@ -248,7 +262,7 @@ describe("component template", () => {
             <ComponentWithTemplates itemComponent={ItemTemplate} />
         );
 
-        renderItemTemplate({ key: "key_1" });
+        renderItemTemplate({ key: "key_1" }, undefined, 5);
         component.update();
         expect(component.find(".template").html()).toBe('<div class="template">key: , dxkey: key_1</div>');
     });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,7 @@ interface IOptions {
   }
 
 let config: IOptions = {
-    useLegacyTemplatEngine: false
+    useLegacyTemplatEngine: true
 };
 
 function setOptions(options: Partial<IOptions>): void {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,18 @@
+interface IOptions {
+    useLegacyTemplatEngine: boolean;
+  }
+
+let config: IOptions = {
+    useLegacyTemplatEngine: false
+};
+
+function setOptions(options: Partial<IOptions>): void {
+    config = {...config, ... options};
+}
+
+function getOption<TName extends keyof IOptions>(optionName: TName): IOptions[TName] {
+    return config[optionName];
+}
+
+export default setOptions;
+export { getOption };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,9 +1,9 @@
 interface IOptions {
-    useLegacyTemplatEngine: boolean;
+    useLegacyTemplateEngine: boolean;
   }
 
 let config: IOptions = {
-    useLegacyTemplatEngine: true
+    useLegacyTemplateEngine: true
 };
 
 function setOptions(options: Partial<IOptions>): void {

--- a/src/core/dx-template.ts
+++ b/src/core/dx-template.ts
@@ -16,7 +16,7 @@ interface IDxTemplateData {
 }
 
 function createDxTemplate(
-    createContentProvider: () => (model: any, index?: number) => any,
+    createContentProvider: () => (model: any) => any,
     templateUpdater: ITemplateUpdater,
     keyFn?: (data: any) => string
 ): IDxTemplate {
@@ -48,7 +48,7 @@ function createDxTemplate(
                 return React.createElement<ITemplateWrapperProps>(
                     TemplateWrapper,
                     {
-                        content: contentProvider(model, data.index),
+                        content: contentProvider({ data: model, index: data.index }),
                         container,
                         onRemoved: () => {
                             templateUpdater.removeTemplate(templateId);

--- a/src/core/dx-template.ts
+++ b/src/core/dx-template.ts
@@ -16,7 +16,7 @@ interface IDxTemplateData {
 }
 
 function createDxTemplate(
-    createContentProvider: () => (model: any) => any,
+    createContentProvider: () => (model: any, index?: number) => any,
     templateUpdater: ITemplateUpdater,
     keyFn?: (data: any) => string
 ): IDxTemplate {
@@ -48,7 +48,7 @@ function createDxTemplate(
                 return React.createElement<ITemplateWrapperProps>(
                     TemplateWrapper,
                     {
-                        content: contentProvider(model),
+                        content: contentProvider(model, data.index),
                         container,
                         onRemoved: () => {
                             templateUpdater.removeTemplate(templateId);

--- a/src/core/dx-template.ts
+++ b/src/core/dx-template.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { generateID } from "./helpers";
+import { ITemplateArgs } from "./template";
 import { ITemplateUpdater } from "./template-updater";
 import { ITemplateWrapperProps, TemplateWrapper } from "./template-wrapper";
 
@@ -16,7 +17,7 @@ interface IDxTemplateData {
 }
 
 function createDxTemplate(
-    createContentProvider: () => (model: any) => any,
+    createContentProvider: () => (props: ITemplateArgs) => any,
     templateUpdater: ITemplateUpdater,
     keyFn?: (data: any) => string
 ): IDxTemplate {
@@ -40,19 +41,20 @@ function createDxTemplate(
             const container = unwrapElement(data.container);
 
             templateUpdater.setTemplate(templateId, () => {
-                const model = data.model;
-                if (model && model.hasOwnProperty("key")) {
-                    model.dxkey = model.key;
-                }
+                const props: ITemplateArgs = {
+                    data: data.model,
+                    index: data.index
+                };
+
                 const contentProvider = createContentProvider();
                 return React.createElement<ITemplateWrapperProps>(
                     TemplateWrapper,
                     {
-                        content: contentProvider({ data: model, index: data.index }),
+                        content: contentProvider(props),
                         container,
                         onRemoved: () => {
                             templateUpdater.removeTemplate(templateId);
-                            renderedModels.delete(model);
+                            renderedModels.delete(props);
                         },
                         onRendered: data.onRendered,
                         key: templateId

--- a/src/core/template-host.ts
+++ b/src/core/template-host.ts
@@ -16,7 +16,7 @@ interface IIntegrationDescr {
 }
 
 function normalizeProps(props: ITemplateArgs) {
-    if (getConfigOption("useLegacyTemplatEngine")) {
+    if (getConfigOption("useLegacyTemplateEngine")) {
         const model = props.data;
         if (model && model.hasOwnProperty("key")) {
             model.dxkey = model.key;

--- a/src/core/template-host.ts
+++ b/src/core/template-host.ts
@@ -16,7 +16,7 @@ interface IIntegrationDescr {
 
 const contentCreators = {
     component: (name: string, propsGetter: PropsGetter) => React.createElement.bind(null, propsGetter(name)),
-    render: (name: string, propsGetter: PropsGetter) => propsGetter(name),
+    render: (name: string, propsGetter: PropsGetter) => (data) => propsGetter(name)(data.data, data.index),
     children: (_: string, propsGetter: PropsGetter) => () => propsGetter("children")
 };
 

--- a/src/core/template-host.ts
+++ b/src/core/template-host.ts
@@ -15,7 +15,7 @@ interface IIntegrationDescr {
     useChildren: (name: string) => boolean;
 }
 
-function normalizeProps(props: ITemplateArgs) {
+function normalizeProps(props: ITemplateArgs): ITemplateArgs | ITemplateArgs["data"] {
     if (getConfigOption("useLegacyTemplateEngine")) {
         const model = props.data;
         if (model && model.hasOwnProperty("key")) {

--- a/src/core/template.ts
+++ b/src/core/template.ts
@@ -16,6 +16,11 @@ interface ITemplateProps {
     keyFn?: (data: any) => string;
 }
 
+interface ITemplateArgs {
+    data: any;
+    index?: number;
+}
+
 class Template extends React.PureComponent<ITemplateProps, any> {
     public render() {
         return null;
@@ -52,6 +57,7 @@ function findProps(child: React.ReactElement<any>): ITemplateProps | undefined {
 export {
     ITemplateMeta,
     ITemplateProps,
+    ITemplateArgs,
     Template,
     findProps
 };


### PR DESCRIPTION
Fixes [T726496](https://www.devexpress.com/Support/Center/Question/Details/T726496/there-is-no-way-to-access-the-item-index-in-a-template-in-a-collection-widget).
Config option `useLegacyTemplatEngine` will be set to `false` after all the depended code such as Demos will be prepared.