### PR TITLE
New eslint rules 6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,8 +24,6 @@
         "no-prototype-builtins": "off",
         "react/forbid-prop-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-use-before-define": "off",
-        "@typescript-eslint/no-shadow": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off"
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,13 +14,8 @@
         "class-methods-use-this": "off",
         "import/extensions": "off",
         "import/no-cycle": "off",
-        "import/no-extraneous-dependencies": "off",
-        "import/no-named-as-default": "off",
-        "jsx-a11y/no-static-element-interactions": "off",
-        "jsx-a11y/click-events-have-key-events": "off",
         "no-param-reassign": "off",
         "no-underscore-dangle": "off",
-        "no-alert": "off",
         "no-prototype-builtins": "off",
         "react/forbid-prop-types": "off",
         "@typescript-eslint/no-explicit-any": "off"

--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,6 @@
         "no-alert": "off",
         "no-prototype-builtins": "off",
         "react/forbid-prop-types": "off",
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off"
+        "@typescript-eslint/no-explicit-any": "off"
     }
 }

--- a/example/accordion-example.tsx
+++ b/example/accordion-example.tsx
@@ -17,7 +17,7 @@ const items: IAccordionItemProps[] = [
 
 const ItemTitle = (data: IAccordionItemProps) => <div style={{ height: 100 }}>{data.title}</div>;
 
-export default (): React.ReactNode => (
+export default (): React.ReactElement | null => (
   <Example title="DxAccordion">
     <hr />
     <h4>Simple Accordion</h4>

--- a/example/accordion-example.tsx
+++ b/example/accordion-example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import Accordion from '../src/accordion';
+import { Accordion } from '../src/accordion';
 
 import Example from './example-block';
 

--- a/example/accordion-example.tsx
+++ b/example/accordion-example.tsx
@@ -17,7 +17,7 @@ const items: IAccordionItemProps[] = [
 
 const ItemTitle = (data: IAccordionItemProps) => <div style={{ height: 100 }}>{data.title}</div>;
 
-export default () => (
+export default (): React.ReactNode => (
   <Example title="DxAccordion">
     <hr />
     <h4>Simple Accordion</h4>

--- a/example/box-example.tsx
+++ b/example/box-example.tsx
@@ -18,7 +18,7 @@ const initialState = {
 };
 
 class App extends React.Component<any, typeof initialState> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
 
     this.state = { ...initialState };

--- a/example/box-example.tsx
+++ b/example/box-example.tsx
@@ -51,7 +51,7 @@ class App extends React.Component<any, typeof initialState> {
     this.setState({ items });
   };
 
-  public render() {
+  public render(): React.ReactNode {
     return (
       <Example title="Box example">
         <Button

--- a/example/box-example.tsx
+++ b/example/box-example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import Box, { Item } from '../src/box';
-import Button from '../src/button';
+import { Box, Item } from '../src/box';
+import { Button } from '../src/button';
 import Example from './example-block';
 
 const initialState = {

--- a/example/chart-example.tsx
+++ b/example/chart-example.tsx
@@ -15,6 +15,44 @@ interface IState {
   series: any[];
 }
 
+class Updater extends React.Component<{ onChange: (value: string) => void }, { value: string }> {
+  constructor(props: { onChange: (value: string) => void }) {
+    super(props);
+    this.state = {
+      value: '',
+    };
+
+    this.update = this.update.bind(this);
+    this.fireOnChange = this.fireOnChange.bind(this);
+  }
+
+  private fireOnChange() {
+    const { onChange } = this.props;
+    const { value } = this.state;
+    onChange(value);
+  }
+
+  private update(e: any) {
+    this.setState({
+      value: e.value,
+    });
+  }
+
+  public render() {
+    const { value } = this.state;
+    return (
+      <div className="dx-field">
+        <div className="dx-field-label">
+          <TextBox value={value} onValueChanged={this.update} valueChangeEvent="input" />
+        </div>
+        <div className="dx-field-value">
+          <Button text="Update series name" onClick={this.fireOnChange} />
+        </div>
+      </div>
+    );
+  }
+}
+
 export default class extends React.Component<any, IState> {
   constructor(props: any) {
     super(props);
@@ -72,44 +110,6 @@ export default class extends React.Component<any, IState> {
         <Chart dataSource={orangesByDay} series={series} />
 
       </Example>
-    );
-  }
-}
-
-class Updater extends React.Component<{ onChange: (value: string) => void }, { value: string }> {
-  constructor(props: { onChange: (value: string) => void }) {
-    super(props);
-    this.state = {
-      value: '',
-    };
-
-    this.update = this.update.bind(this);
-    this.fireOnChange = this.fireOnChange.bind(this);
-  }
-
-  private fireOnChange() {
-    const { onChange } = this.props;
-    const { value } = this.state;
-    onChange(value);
-  }
-
-  private update(e: any) {
-    this.setState({
-      value: e.value,
-    });
-  }
-
-  public render() {
-    const { value } = this.state;
-    return (
-      <div className="dx-field">
-        <div className="dx-field-label">
-          <TextBox value={value} onValueChanged={this.update} valueChangeEvent="input" />
-        </div>
-        <div className="dx-field-value">
-          <Button text="Update series name" onClick={this.fireOnChange} />
-        </div>
-      </div>
     );
   }
 }

--- a/example/chart-example.tsx
+++ b/example/chart-example.tsx
@@ -54,7 +54,7 @@ class Updater extends React.Component<{ onChange: (value: string) => void }, { v
 }
 
 export default class extends React.Component<any, IState> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       currentTime: this.GetTimeString(),

--- a/example/chart-example.tsx
+++ b/example/chart-example.tsx
@@ -5,9 +5,9 @@ import * as React from 'react';
 import { orangesByDay } from './data';
 import Example from './example-block';
 
-import Button from '../src/button';
-import Chart from '../src/chart';
-import TextBox from '../src/text-box';
+import { Button } from '../src/button';
+import { Chart } from '../src/chart';
+import { TextBox } from '../src/text-box';
 
 interface IState {
   currentTime: string;

--- a/example/chart-example.tsx
+++ b/example/chart-example.tsx
@@ -89,7 +89,7 @@ export default class extends React.Component<any, IState> {
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { currentTime, series } = this.state;
     return (
       <Example title="DxChart" state={this.state}>

--- a/example/data-grid-example.tsx
+++ b/example/data-grid-example.tsx
@@ -37,7 +37,7 @@ const RegionComponent = (props: any) => {
 };
 
 export default class extends React.Component<any, { expandAll: boolean, pageSize: number }> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       expandAll: true,

--- a/example/data-grid-example.tsx
+++ b/example/data-grid-example.tsx
@@ -75,7 +75,7 @@ export default class extends React.Component<any, { expandAll: boolean, pageSize
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { expandAll, pageSize } = this.state;
     return (
       <Example title="DxDataGrid" state={this.state}>

--- a/example/data-grid-example.tsx
+++ b/example/data-grid-example.tsx
@@ -3,7 +3,8 @@ import Example from './example-block';
 
 import { Template } from '../src/core/template';
 
-import DataGrid, {
+import {
+  DataGrid,
   Column,
   FilterRow,
   Grouping,
@@ -13,7 +14,7 @@ import DataGrid, {
   Paging,
   Selection,
 } from '../src/data-grid';
-import NumberBox from '../src/number-box';
+import { NumberBox } from '../src/number-box';
 
 import { sales } from './data';
 

--- a/example/editor-example.tsx
+++ b/example/editor-example.tsx
@@ -10,7 +10,7 @@ function fieldRender() {
 }
 
 export default class extends React.Component<any, any> {
-  public render() {
+  public render(): React.ReactNode {
     return (
       <Example title="Editors" state={this.state}>
         <SelectBox fieldRender={fieldRender} />

--- a/example/example-block.tsx
+++ b/example/example-block.tsx
@@ -6,7 +6,7 @@ interface IProps {
   children: any;
 }
 
-const Example = (props: IProps) => {
+const Example = (props: IProps): React.ReactNode => {
   const { state, title, children } = props;
   let stateBlock = null;
   if (state) {

--- a/example/form-example.tsx
+++ b/example/form-example.tsx
@@ -35,7 +35,7 @@ const getTextBoxComponent = (disabled: boolean) => (props: any) => {
 };
 
 export default class extends React.Component<any, {disableIdInput: boolean}> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
 
     this.state = {

--- a/example/form-example.tsx
+++ b/example/form-example.tsx
@@ -48,7 +48,7 @@ export default class extends React.Component<any, {disableIdInput: boolean}> {
     this.setState({ disableIdInput: !disableIdInput });
   };
 
-  public render() {
+  public render(): React.ReactNode {
     const { disableIdInput } = this.state;
     return (
       <Example title="DxForm">

--- a/example/form-example.tsx
+++ b/example/form-example.tsx
@@ -29,6 +29,11 @@ const positions = [
   'Shipping Manager',
 ];
 
+const getTextBoxComponent = (disabled: boolean) => (props: any) => {
+  const { data } = props;
+  return <NumberBox disabled={disabled} value={data.editorOptions.value} />;
+};
+
 export default class extends React.Component<any, {disableIdInput: boolean}> {
   constructor(props: any) {
     super(props);
@@ -94,8 +99,3 @@ export default class extends React.Component<any, {disableIdInput: boolean}> {
     );
   }
 }
-
-const getTextBoxComponent = (disabled: boolean) => (props: any) => {
-  const { data } = props;
-  return <NumberBox disabled={disabled} value={data.editorOptions.value} />;
-};

--- a/example/form-example.tsx
+++ b/example/form-example.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import Example from './example-block';
 
 import { Button, NumberBox } from '../src';
-import Form, {
-  GroupItem, Item, RequiredRule, SimpleItem,
+import {
+  Form, GroupItem, Item, RequiredRule, SimpleItem,
 } from '../src/form';
-import TextArea from '../src/text-area';
+import { TextArea } from '../src/text-area';
 
 const employee: any = {
   ID: 1,

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -70,7 +70,7 @@ const listItems: string[] = ['orange', 'apple', 'potato'];
 export default class extends React.Component<any, { text: string; items: IListItemProps[]; }> {
   private dataSource: DataSource;
 
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       text: '',

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -43,7 +43,7 @@ class Item extends React.Component<IListItemProps, { counter: number }> {
     const { data: { text }, index } = this.props;
     const { counter } = this.state;
     return (
-      <i onClick={this.handleClick}>
+      <button type="button" onClick={this.handleClick}>
         {index + 1}
         . Component template for item
         {text}
@@ -52,7 +52,7 @@ class Item extends React.Component<IListItemProps, { counter: number }> {
           Clicks:
           {counter}
         </b>
-      </i>
+      </button>
     );
   }
 }

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -16,6 +16,12 @@ interface IListItemProps {
   index: number;
 }
 
+const items: IListItemProps[] = [
+  { text: '123' },
+  { text: '234' },
+  { text: '567' },
+];
+
 class Item extends React.Component<IListItemProps, { counter: number }> {
   constructor(props: IListItemProps) {
     super(props);
@@ -99,15 +105,15 @@ export default class extends React.Component<any, { text: string; items: IListIt
   }
 
   private addTextToList() {
-    const { items, text } = this.state;
+    const { items: stateItems, text } = this.state;
     this.setState({
-      items: [...items, { text }],
+      items: [...stateItems, { text }],
       text: '',
     });
   }
 
   public render() {
-    const { items, text } = this.state;
+    const { items: stateItems, text } = this.state;
     return (
       <Example title="DxList" state={this.state}>
         <hr />
@@ -127,7 +133,7 @@ export default class extends React.Component<any, { text: string; items: IListIt
         <h4>List with component template</h4>
         <List
           repaintChangesOnly
-          items={items}
+          items={stateItems}
           itemComponent={Item}
           itemKeyFn={ItemKeyGetter}
         />
@@ -142,9 +148,3 @@ export default class extends React.Component<any, { text: string; items: IListIt
     );
   }
 }
-
-const items: IListItemProps[] = [
-  { text: '123' },
-  { text: '234' },
-  { text: '567' },
-];

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -94,7 +94,7 @@ export default class extends React.Component<any, { text: string; items: IListIt
     this.addTextToList = this.addTextToList.bind(this);
   }
 
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     this.dataSource.dispose();
   }
 
@@ -112,7 +112,7 @@ export default class extends React.Component<any, { text: string; items: IListIt
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { items: stateItems, text } = this.state;
     return (
       <Example title="DxList" state={this.state}>

--- a/example/list-example.tsx
+++ b/example/list-example.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 
 import DataSource from 'devextreme/data/data_source';
 
-import Button from '../src/button';
-import List, { Item as ListItem } from '../src/list';
-import TextBox from '../src/text-box';
+import { Button } from '../src/button';
+import { List, Item as ListItem } from '../src/list';
+import { TextBox } from '../src/text-box';
 
 import Example from './example-block';
 

--- a/example/map-example.tsx
+++ b/example/map-example.tsx
@@ -17,7 +17,7 @@ const startPos = {
 };
 
 export default class extends React.Component<any, { text: string; pos: IPosition }> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     const pos = { ...startPos };
     this.state = {

--- a/example/map-example.tsx
+++ b/example/map-example.tsx
@@ -28,7 +28,7 @@ export default class extends React.Component<any, { text: string; pos: IPosition
     this.updatePos = this.updatePos.bind(this);
   }
 
-  public updatePos() {
+  public updatePos(): void {
     const { pos: { lat, lng } } = this.state;
     const pos = {
       lat: lat + 0.01,
@@ -41,7 +41,7 @@ export default class extends React.Component<any, { text: string; pos: IPosition
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { pos } = this.state;
     return (
       <Example title="dxMap" state={this.state}>

--- a/example/map-example.tsx
+++ b/example/map-example.tsx
@@ -2,8 +2,8 @@
 import * as React from 'react';
 import Example from './example-block';
 
-import Map, {
-  Location, Marker, Route, Tooltip,
+import {
+  Map, Location, Marker, Route, Tooltip,
 } from '../src/map';
 
 interface IPosition {

--- a/example/popup-example.tsx
+++ b/example/popup-example.tsx
@@ -34,7 +34,7 @@ export default class extends React.Component<any, { visible: boolean; text: stri
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { text, visible } = this.state;
     return (
       <Example title="DxPopup" state={this.state}>

--- a/example/popup-example.tsx
+++ b/example/popup-example.tsx
@@ -10,7 +10,7 @@ const VALID_TEXT = 'good';
 const validateText = (text: string) => text === VALID_TEXT;
 
 export default class extends React.Component<any, { visible: boolean; text: string; }> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       visible: false,

--- a/example/popup-example.tsx
+++ b/example/popup-example.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-import Button from '../src/button';
-import Popup from '../src/popup';
-import ScrollView from '../src/scroll-view';
-import TextBox from '../src/text-box';
+import { Button } from '../src/button';
+import { Popup } from '../src/popup';
+import { ScrollView } from '../src/scroll-view';
+import { TextBox } from '../src/text-box';
 import Example from './example-block';
 
 const VALID_TEXT = 'good';

--- a/example/scheduler-example.tsx
+++ b/example/scheduler-example.tsx
@@ -20,7 +20,7 @@ class DateCell extends React.PureComponent<any> {
   }
 }
 
-export default (): React.ReactNode => (
+export default (): React.ReactElement | null => (
   <Example title="DxScheduler">
     <Scheduler
       dateCellComponent={DateCell}

--- a/example/scheduler-example.tsx
+++ b/example/scheduler-example.tsx
@@ -6,7 +6,7 @@ import { Scheduler } from '../src/scheduler';
 import { appointments } from './data';
 
 class DateCell extends React.PureComponent<any> {
-  public render() {
+  public render(): React.ReactNode {
     const { data } = this.props;
     const { date: now, text } = data;
     const start = new Date(now.getFullYear(), 0, 0).getTime();
@@ -20,7 +20,7 @@ class DateCell extends React.PureComponent<any> {
   }
 }
 
-export default () => (
+export default (): React.ReactNode => (
   <Example title="DxScheduler">
     <Scheduler
       dateCellComponent={DateCell}

--- a/example/scroll-view-example.tsx
+++ b/example/scroll-view-example.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 /* eslint-disable max-len */
 import * as React from 'react';
 

--- a/example/scroll-view-example.tsx
+++ b/example/scroll-view-example.tsx
@@ -30,7 +30,7 @@ export default class extends React.Component<any, { text: string }> {
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { text } = this.state;
     return (
       <Example title="DxScrollView" state={this.state}>

--- a/example/scroll-view-example.tsx
+++ b/example/scroll-view-example.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import Example from './example-block';
 
-import Button from '../src/button';
-import ScrollView from '../src/scroll-view';
-import TextBox from '../src/text-box';
+import { Button } from '../src/button';
+import { ScrollView } from '../src/scroll-view';
+import { TextBox } from '../src/text-box';
 
 export default class extends React.Component<any, { text: string }> {
   constructor(props: any) {

--- a/example/scroll-view-example.tsx
+++ b/example/scroll-view-example.tsx
@@ -9,7 +9,7 @@ import { ScrollView } from '../src/scroll-view';
 import { TextBox } from '../src/text-box';
 
 export default class extends React.Component<any, { text: string }> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       text: 'Clear me',

--- a/example/selectbox-example.tsx
+++ b/example/selectbox-example.tsx
@@ -3,19 +3,6 @@ import { SelectBox } from '../src/select-box';
 
 const SelectBoxItem = (option: any) => <span>{option.data.value}</span>;
 
-export default () => (
-  <SelectBox
-    searchEnabled
-    showClearButton
-    searchTimeout={0}
-    noDataText="No results found"
-    displayExpr="label"
-    valueExpr="value"
-    items={items}
-    itemComponent={SelectBoxItem}
-  />
-);
-
 const items = [
   {
     label: '1',
@@ -38,3 +25,16 @@ const items = [
     value: '5',
   },
 ];
+
+export default () => (
+  <SelectBox
+    searchEnabled
+    showClearButton
+    searchTimeout={0}
+    noDataText="No results found"
+    displayExpr="label"
+    valueExpr="value"
+    items={items}
+    itemComponent={SelectBoxItem}
+  />
+);

--- a/example/selectbox-example.tsx
+++ b/example/selectbox-example.tsx
@@ -26,7 +26,7 @@ const items = [
   },
 ];
 
-export default () => (
+export default (): React.ReactNode => (
   <SelectBox
     searchEnabled
     showClearButton

--- a/example/selectbox-example.tsx
+++ b/example/selectbox-example.tsx
@@ -26,7 +26,7 @@ const items = [
   },
 ];
 
-export default (): React.ReactNode => (
+export default (): React.ReactElement | null => (
   <SelectBox
     searchEnabled
     showClearButton

--- a/example/slide-out-view-example.tsx
+++ b/example/slide-out-view-example.tsx
@@ -29,7 +29,7 @@ function renderMenuTemplate() {
 }
 
 export default class extends React.Component<any, any> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       menuVisible: true,

--- a/example/slide-out-view-example.tsx
+++ b/example/slide-out-view-example.tsx
@@ -38,7 +38,7 @@ export default class extends React.Component<any, any> {
     this.toggle = this.toggle.bind(this);
   }
 
-  public toggle() {
+  public toggle(): void {
     const { menuVisible } = this.state;
     this.setState({ menuVisible: !menuVisible });
   }
@@ -49,7 +49,7 @@ export default class extends React.Component<any, any> {
     }
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { menuVisible } = this.state;
     return (
       <Example title="DxSlideOutView" state={this.state}>

--- a/example/standalone-validator.tsx
+++ b/example/standalone-validator.tsx
@@ -13,7 +13,7 @@ class ValidatorExample extends React.Component<any, any> {
 
   private _callbacks: any[] = [];
 
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       isValid: true,

--- a/example/standalone-validator.tsx
+++ b/example/standalone-validator.tsx
@@ -40,7 +40,7 @@ class ValidatorExample extends React.Component<any, any> {
     e.validationGroup.validate();
   };
 
-  public render() {
+  public render(): React.ReactNode {
     const { isValid } = this.state;
     return (
       <div>

--- a/example/text-box-example.tsx
+++ b/example/text-box-example.tsx
@@ -38,7 +38,7 @@ export default class extends React.Component<any, { text: string; uncontrolledTe
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { text } = this.state;
     return (
       <Example title="DxTextBox" state={this.state}>

--- a/example/text-box-example.tsx
+++ b/example/text-box-example.tsx
@@ -10,7 +10,7 @@ import { RequiredRule, Validator } from '../src/validator';
 export default class extends React.Component<any, { text: string; uncontrolledText: string; }> {
   private textBox: dxTextBox;
 
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
     this.state = {
       text: 'text',

--- a/example/toolbar-example.tsx
+++ b/example/toolbar-example.tsx
@@ -11,7 +11,7 @@ const ItemComponent = (data: {data: {text: string}}) => (
 const items = [{ text: 'Text' }, { text: 'Text2' }];
 
 export default class extends React.Component<any, any> {
-  public render() {
+  public render(): React.ReactNode {
     return (
       <Example title="Toolbar" state={this.state}>
         <Toolbar items={items} itemComponent={ItemComponent} />

--- a/example/validation-example.tsx
+++ b/example/validation-example.tsx
@@ -8,7 +8,7 @@ import { ValidationSummary } from '../src/validation-summary';
 import { EmailRule, RequiredRule, Validator } from '../src/validator';
 
 export default class extends React.Component<any, any> {
-  constructor(props: any) {
+  constructor(props: unknown) {
     super(props);
 
     this.validate = this.validate.bind(this);

--- a/example/validation-example.tsx
+++ b/example/validation-example.tsx
@@ -22,7 +22,7 @@ export default class extends React.Component<any, any> {
     }
   }
 
-  public render() {
+  public render(): React.ReactNode {
     return (
       <Example title="Validation" state={this.state}>
         <ValidationGroup>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2816,8 +2816,7 @@
     "dasherize": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg=",
-      "dev": true
+      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -3194,8 +3193,7 @@
     "dot": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.3.tgz",
-      "integrity": "sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg==",
-      "dev": true
+      "integrity": "sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg=="
     },
     "duplexify": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "eslint-plugin-jest-formatting": "^2.0.0",
     "eslint-plugin-qunit": "^5.0.0",
     "eslint-plugin-spellcheck": "0.0.17",
-    "prop-types": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "dasherize": "^2.0.0",
+    "dot": "^1.1.2"
   },
   "peerDependencies": {
     "devextreme": "~20.1.7",
@@ -34,11 +36,9 @@
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "css-loader": "^2.1.0",
-    "dasherize": "^2.0.0",
     "del": "^3.0.0",
     "devextreme": "~20.1.7",
     "devextreme-internal-tools": "stable",
-    "dot": "^1.1.2",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
     "eslint": "^7.11.0",

--- a/src/core/__tests__/dx-template.test.tsx
+++ b/src/core/__tests__/dx-template.test.tsx
@@ -5,6 +5,28 @@ describe('dx-template', () => {
   describe('multiple rendering', () => {
     const container = {};
     const anotherContainer = {};
+    const templatesStore: any = {
+      add: jest.fn(),
+      remove: jest.fn(),
+      renderWrappers: jest.fn(),
+    };
+
+    function tryDoubleRender(model1: any, container1: any, model2: any, container2: any): void {
+      const template = createDxTemplate(
+        jest.fn(),
+        templatesStore as TemplatesStore,
+      );
+
+      template.render({
+        container: container1,
+        model: model1,
+      });
+
+      template.render({
+        container: container2,
+        model: model2,
+      });
+    }
 
     beforeEach(() => {
       jest.resetAllMocks();
@@ -93,27 +115,5 @@ describe('dx-template', () => {
         expect(secondId).not.toBe(firstId);
       });
     });
-
-    const templatesStore: any = {
-      add: jest.fn(),
-      remove: jest.fn(),
-      renderWrappers: jest.fn(),
-    };
-    function tryDoubleRender(model1: any, container1: any, model2: any, container2: any): void {
-      const template = createDxTemplate(
-        jest.fn(),
-        templatesStore as TemplatesStore,
-      );
-
-      template.render({
-        container: container1,
-        model: model1,
-      });
-
-      template.render({
-        container: container2,
-        model: model2,
-      });
-    }
   });
 });

--- a/src/core/__tests__/props-updating.test.tsx
+++ b/src/core/__tests__/props-updating.test.tsx
@@ -555,6 +555,20 @@ describe('cfg-component option defaults control', () => {
 });
 
 describe('mutation detection', () => {
+  const expectNoPropsUpdate = () => {
+    expect(Widget.option.mock.calls.length).toBe(0);
+    expect(Widget.beginUpdate.mock.calls.length).toBe(0);
+    expect(Widget.endUpdate.mock.calls.length).toBe(0);
+  };
+
+  const expectPropsUpdated = (expectedPath: string, value: any) => {
+    expect(Widget.option.mock.calls.length).toBe(1);
+    expect(Widget.beginUpdate.mock.calls.length).toBe(1);
+    expect(Widget.endUpdate.mock.calls.length).toBe(1);
+    expect(Widget.option.mock.calls[0][0]).toEqual(expectedPath);
+    expect(Widget.option.mock.calls[0][1]).toEqual(value);
+  };
+
   it('prevents update if no option changed', () => {
     const component = shallow(
       <TestComponent prop="abc" />,
@@ -610,20 +624,6 @@ describe('mutation detection', () => {
 
     expectPropsUpdated('anotherProp', 456);
   });
-
-  const expectNoPropsUpdate = () => {
-    expect(Widget.option.mock.calls.length).toBe(0);
-    expect(Widget.beginUpdate.mock.calls.length).toBe(0);
-    expect(Widget.endUpdate.mock.calls.length).toBe(0);
-  };
-
-  const expectPropsUpdated = (expectedPath: string, value: any) => {
-    expect(Widget.option.mock.calls.length).toBe(1);
-    expect(Widget.beginUpdate.mock.calls.length).toBe(1);
-    expect(Widget.endUpdate.mock.calls.length).toBe(1);
-    expect(Widget.option.mock.calls[0][0]).toEqual(expectedPath);
-    expect(Widget.option.mock.calls[0][1]).toEqual(value);
-  };
 });
 
 describe('onXXXChange', () => {

--- a/src/core/__tests__/template.test.tsx
+++ b/src/core/__tests__/template.test.tsx
@@ -754,10 +754,12 @@ describe('component/render in nested options', () => {
     const items = [{ id: 1, render: renderItem }];
 
     const TestContainer = (props: any) => {
-      const { items } = props;
+      const { items: propItems } = props;
       return (
         <TestComponent>
-          {items.map((item) => <CollectionNestedComponent key={item.id} render={item.render} />)}
+          {propItems.map(
+            (item) => <CollectionNestedComponent key={item.id} render={item.render} />,
+          )}
         </TestComponent>
       );
     };
@@ -789,10 +791,12 @@ describe('component/render in nested options', () => {
     const items = [{ id: 1, render: renderItem }, { id: 2, render: renderItem }];
 
     const TestContainer = (props: any) => {
-      const { items } = props;
+      const { items: propItems } = props;
       return (
         <TestComponent>
-          {items.map((item) => <CollectionNestedComponent key={item.id} render={item.render} />)}
+          {propItems.map(
+            (item) => <CollectionNestedComponent key={item.id} render={item.render} />,
+          )}
         </TestComponent>
       );
     };
@@ -814,10 +818,12 @@ describe('component/render in nested options', () => {
     const items = [{ id: 1, render: ItemTemplate }, { id: 2, render: ItemTemplate }];
 
     const TestContainer = (props: any) => {
-      const { items } = props;
+      const { items: propItems } = props;
       return (
         <TestComponent>
-          {items.map((item) => <CollectionNestedComponent key={item.id} render={item.render} />)}
+          {propItems.map(
+            (item) => <CollectionNestedComponent key={item.id} render={item.render} />,
+          )}
         </TestComponent>
       );
     };

--- a/src/core/__tests__/test-component.ts
+++ b/src/core/__tests__/test-component.ts
@@ -7,7 +7,7 @@ const Widget = {
   resetOption: jest.fn(),
   beginUpdate: jest.fn(),
   endUpdate: jest.fn(),
-  on: (event: string, handler: (e: any) => void) => {
+  on: (event: string, handler: (e: any) => void): void => {
     eventHandlers[event] = handler;
   },
   dispose: jest.fn(),
@@ -19,7 +19,7 @@ class TestComponent<P = any> extends Component<P> {
   protected _WidgetClass = WidgetClass;
 }
 
-function fireOptionChange(fullName: string, value: any) {
+function fireOptionChange(fullName: string, value: any): void {
   eventHandlers.optionChanged({
     name: fullName.split('.')[0],
     fullName,

--- a/src/core/__tests__/test-component.ts
+++ b/src/core/__tests__/test-component.ts
@@ -19,7 +19,7 @@ class TestComponent<P = any> extends Component<P> {
   protected _WidgetClass = WidgetClass;
 }
 
-function fireOptionChange(fullName: string, value: any): void {
+function fireOptionChange(fullName: string, value: unknown): void {
   eventHandlers.optionChanged({
     name: fullName.split('.')[0],
     fullName,

--- a/src/core/component-base.ts
+++ b/src/core/component-base.ts
@@ -56,11 +56,11 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
     this._optionsManager = new OptionsManager(this._templatesManager);
   }
 
-  public componentDidMount() {
+  public componentDidMount(): void {
     this._updateCssClasses(null, this.props);
   }
 
-  public componentDidUpdate(prevProps: P) {
+  public componentDidUpdate(prevProps: P): void {
     this._updateCssClasses(prevProps, this.props);
 
     const config = this._getConfig();
@@ -70,7 +70,7 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
     }
   }
 
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     if (this._instance) {
       events.triggerHandler(this._element, DX_REMOVE_EVENT);
       this._instance.dispose();
@@ -78,7 +78,7 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
     this._optionsManager.dispose();
   }
 
-  protected _createWidget(element?: Element) {
+  protected _createWidget(element?: Element): void {
     element = element || this._element;
 
     const config = this._getConfig();
@@ -145,12 +145,12 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
     }
   }
 
-  protected renderChildren() {
+  protected renderChildren(): React.ReactNode {
     const { children } = this.props;
     return children;
   }
 
-  public render() {
+  public render(): React.ReactNode {
     return React.createElement(
       'div',
       this._getElementProps(),

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -12,13 +12,13 @@ class Component<P> extends ComponentBase<P> {
     this._registerExtension = this._registerExtension.bind(this);
   }
 
-  public componentDidMount() {
+  public componentDidMount(): void {
     super.componentDidMount();
     this._createWidget();
     this._createExtensions();
   }
 
-  protected renderChildren() {
+  protected renderChildren(): Record<string, unknown>[]|null| undefined {
     return React.Children.map(
       this.props.children,
       (child) => {

--- a/src/core/configuration/comparer.ts
+++ b/src/core/configuration/comparer.ts
@@ -91,7 +91,7 @@ function appendRemovedValues(
   });
 }
 
-function getChanges(current: IConfigNode, prev: IConfigNode) {
+function getChanges(current: IConfigNode, prev: IConfigNode): IConfigChanges {
   const changesAccum: IConfigChanges = {
     options: {},
     removedOptions: [],

--- a/src/core/configuration/comparer.ts
+++ b/src/core/configuration/comparer.ts
@@ -10,56 +10,6 @@ interface IConfigChanges {
     currentOptions: Record<string, any>, prevOptions: Record<string, any>, path: string): void;
 }
 
-function getChanges(current: IConfigNode, prev: IConfigNode) {
-  const changesAccum: IConfigChanges = {
-    options: {},
-    removedOptions: [],
-    templates: {},
-    addRemovedValues(currentOptions, prevOptions, path) {
-      appendRemovedValues(currentOptions, prevOptions, path, this.removedOptions);
-    },
-  };
-
-  compare(current, prev, changesAccum);
-
-  return changesAccum;
-}
-
-function compare(current: IConfigNode, prev: IConfigNode, changesAccum: IConfigChanges) {
-  if (!prev) {
-    changesAccum.options[current.fullName] = buildNode(
-      current,
-      changesAccum.templates,
-      true,
-    );
-    return;
-  }
-
-  changesAccum.addRemovedValues(current.options, prev.options, current.fullName);
-  changesAccum.addRemovedValues(
-    current.configCollections,
-    prev.configCollections,
-    current.fullName,
-  );
-  changesAccum.addRemovedValues(current.configs, prev.configs, current.fullName);
-
-  compareCollections(current, prev, changesAccum);
-
-  Object.keys(current.configs).forEach((key) => {
-    compare(current.configs[key], prev.configs[key], changesAccum);
-  });
-
-  Object.keys(current.options).forEach((key) => {
-    if (current.options[key] === prev.options[key]) {
-      return;
-    }
-
-    changesAccum.options[mergeNameParts(current.fullName, key)] = current.options[key];
-  });
-
-  compareTemplates(current, prev, changesAccum);
-}
-
 function compareTemplates(current: IConfigNode, prev: IConfigNode, changesAccum: IConfigChanges) {
   const currentTemplatesOptions: Record<string, any> = {};
   const currentTemplates: Record<string, ITemplate> = {};
@@ -92,6 +42,42 @@ function compareTemplates(current: IConfigNode, prev: IConfigNode, changesAccum:
   });
 }
 
+function compare(current: IConfigNode, prev: IConfigNode, changesAccum: IConfigChanges) {
+  if (!prev) {
+    changesAccum.options[current.fullName] = buildNode(
+      current,
+      changesAccum.templates,
+      true,
+    );
+    return;
+  }
+
+  changesAccum.addRemovedValues(current.options, prev.options, current.fullName);
+  changesAccum.addRemovedValues(
+    current.configCollections,
+    prev.configCollections,
+    current.fullName,
+  );
+  changesAccum.addRemovedValues(current.configs, prev.configs, current.fullName);
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  compareCollections(current, prev, changesAccum);
+
+  Object.keys(current.configs).forEach((key) => {
+    compare(current.configs[key], prev.configs[key], changesAccum);
+  });
+
+  Object.keys(current.options).forEach((key) => {
+    if (current.options[key] === prev.options[key]) {
+      return;
+    }
+
+    changesAccum.options[mergeNameParts(current.fullName, key)] = current.options[key];
+  });
+
+  compareTemplates(current, prev, changesAccum);
+}
+
 function appendRemovedValues(
   current: Record<string, any>,
   prev: Record<string, any>,
@@ -103,6 +89,21 @@ function appendRemovedValues(
   removedKeys.forEach((key) => {
     changesAccum.push(mergeNameParts(path, key));
   });
+}
+
+function getChanges(current: IConfigNode, prev: IConfigNode) {
+  const changesAccum: IConfigChanges = {
+    options: {},
+    removedOptions: [],
+    templates: {},
+    addRemovedValues(currentOptions, prevOptions, path) {
+      appendRemovedValues(currentOptions, prevOptions, path, this.removedOptions);
+    },
+  };
+
+  compare(current, prev, changesAccum);
+
+  return changesAccum;
 }
 
 function compareCollections(

--- a/src/core/configuration/react/element.ts
+++ b/src/core/configuration/react/element.ts
@@ -1,4 +1,4 @@
-import { ITemplateMeta, Template as TemplateFunc } from '../../template';
+import { ITemplateMeta, Template as TemplateComp } from '../../template';
 
 enum ElementType {
   Option,
@@ -48,7 +48,7 @@ function getElementInfo(
     };
   }
 
-  if (reactElement.type === TemplateFunc) {
+  if (reactElement.type === TemplateComp) {
     return {
       type: ElementType.Template,
       props: reactElement.props,

--- a/src/core/configuration/react/element.ts
+++ b/src/core/configuration/react/element.ts
@@ -1,4 +1,4 @@
-import { ITemplateMeta, Template } from '../../template';
+import { ITemplateMeta, Template as TemplateFunc } from '../../template';
 
 enum ElementType {
   Option,
@@ -48,7 +48,7 @@ function getElementInfo(
     };
   }
 
-  if (reactElement.type === Template) {
+  if (reactElement.type === TemplateFunc) {
     return {
       type: ElementType.Template,
       props: reactElement.props,

--- a/src/core/configuration/react/tree.ts
+++ b/src/core/configuration/react/tree.ts
@@ -115,7 +115,10 @@ function createConfigNode(element: IOptionElement, path: string): IConfigNode {
   };
 }
 
-function buildConfigTree(widgetDescriptor: IWidgetDescriptor, props: Record<string, any>) {
+function buildConfigTree(
+  widgetDescriptor: IWidgetDescriptor,
+  props: Record<string, any>,
+): IConfigNode {
   return createConfigNode(
     {
       type: ElementType.Option,

--- a/src/core/configuration/tree.ts
+++ b/src/core/configuration/tree.ts
@@ -10,7 +10,7 @@ function buildTemplates(
   node: IConfigNode,
   optionsAccum: Record<string, any>,
   templatesAccum: Record<string, ITemplate>,
-) {
+): void {
   node.templates.forEach(
     (template) => {
       if (template.isAnonymous) {

--- a/src/core/configuration/utils.ts
+++ b/src/core/configuration/utils.ts
@@ -1,4 +1,4 @@
-export function mergeNameParts(...args: string[]) {
+export function mergeNameParts(...args: string[]): string {
   return args.filter((value) => value).join('.');
 }
 

--- a/src/core/dx-template.ts
+++ b/src/core/dx-template.ts
@@ -16,6 +16,10 @@ interface IDxTemplateData {
   onRendered?: () => void;
 }
 
+function unwrapElement(element: any): HTMLElement {
+  return element.get ? element.get(0) : element;
+}
+
 function createDxTemplate(
   createContentProvider: () => (props: ITemplateArgs) => any,
   templatesStore: TemplatesStore,
@@ -65,10 +69,6 @@ function createDxTemplate(
       return container;
     },
   };
-}
-
-function unwrapElement(element: any): HTMLElement {
-  return element.get ? element.get(0) : element;
 }
 
 export {

--- a/src/core/extension-component.ts
+++ b/src/core/extension-component.ts
@@ -1,7 +1,7 @@
 import { ComponentBase } from './component-base';
 
 class ExtensionComponent<P> extends ComponentBase<P> {
-  public componentDidMount() {
+  public componentDidMount(): void {
     const { onMounted } = this.props as any;
     if (onMounted) {
       onMounted(this._createWidget);

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -5,7 +5,7 @@ export function generateID(): string {
 export class DoubleKeyMap<TKey1, TKey2, TValue> {
   private readonly _map: Map<TKey1, Map<TKey2, TValue>> = new Map();
 
-  public set({ key1, key2 }: { key1: TKey1, key2: TKey2 }, value: TValue) {
+  public set({ key1, key2 }: { key1: TKey1, key2: TKey2 }, value: TValue): void {
     let innerMap = this._map.get(key1);
     if (!innerMap) {
       innerMap = new Map<TKey2, TValue>();

--- a/src/core/nested-option.ts
+++ b/src/core/nested-option.ts
@@ -9,7 +9,7 @@ interface INestedOptionMeta {
 }
 
 class NestedOption<P> extends React.PureComponent<P, any> {
-  public render() {
+  public render(): React.ReactNode {
     const { children: stateChildren } = this.props;
     const children = React.Children.map(
       stateChildren,

--- a/src/core/options-manager.ts
+++ b/src/core/options-manager.ts
@@ -26,7 +26,7 @@ class OptionsManager {
     this._wrapOptionValue = this._wrapOptionValue.bind(this);
   }
 
-  public setInstance(instance: any, config: IConfigNode): void {
+  public setInstance(instance: unknown, config: IConfigNode): void {
     this._instance = instance;
     this._currentConfig = config;
   }

--- a/src/core/options-manager.ts
+++ b/src/core/options-manager.ts
@@ -26,12 +26,12 @@ class OptionsManager {
     this._wrapOptionValue = this._wrapOptionValue.bind(this);
   }
 
-  public setInstance(instance: any, config: IConfigNode) {
+  public setInstance(instance: any, config: IConfigNode): void {
     this._instance = instance;
     this._currentConfig = config;
   }
 
-  public getInitialOptions(rootNode: IConfigNode) {
+  public getInitialOptions(rootNode: IConfigNode): Record<string, any> {
     const config = buildConfig(rootNode, false);
 
     Object.keys(config.templates).forEach((key) => {
@@ -52,7 +52,7 @@ class OptionsManager {
     return options;
   }
 
-  public update(config: IConfigNode) {
+  public update(config: IConfigNode): void {
     const changes = getChanges(config, this._currentConfig);
 
     if (!changes.options && !changes.templates && !changes.removedOptions.length) {
@@ -89,7 +89,7 @@ class OptionsManager {
     this._currentConfig = config;
   }
 
-  public onOptionChanged(e: { name: string, fullName: string, value: any }) {
+  public onOptionChanged(e: { name: string, fullName: string, value: any }): void {
     if (this._isUpdating) {
       return;
     }
@@ -120,7 +120,7 @@ class OptionsManager {
     }
   }
 
-  public dispose() {
+  public dispose(): void {
     Object.keys(this._guards).forEach((optionName) => {
       window.clearTimeout(this._guards[optionName]);
       delete this._guards[optionName];

--- a/src/core/template-wrapper.ts
+++ b/src/core/template-wrapper.ts
@@ -31,18 +31,18 @@ class TemplateWrapper extends React.PureComponent<ITemplateWrapperProps, ITempla
     this._onDxRemove = this._onDxRemove.bind(this);
   }
 
-  public componentDidMount() {
+  public componentDidMount(): void {
     const { onRendered } = this.props;
     onRendered?.();
 
     this._subscribeOnRemove();
   }
 
-  public componentDidUpdate() {
+  public componentDidUpdate(): void {
     this._subscribeOnRemove();
   }
 
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     // Let React remove it itself
     // eslint-disable-next-line react/no-find-dom-node
     const node = ReactDOM.findDOMNode(this);
@@ -90,7 +90,7 @@ class TemplateWrapper extends React.PureComponent<ITemplateWrapperProps, ITempla
     onRemoved();
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { removalListenerRequired } = this.state;
     const { content, container } = this.props;
     const removalListener = removalListenerRequired

--- a/src/core/template.ts
+++ b/src/core/template.ts
@@ -22,7 +22,7 @@ interface ITemplateArgs {
 }
 
 class Template extends React.PureComponent<ITemplateProps, any> {
-  public render() {
+  public render(): React.ReactNode {
     return null;
   }
 }

--- a/src/core/templates-manager.ts
+++ b/src/core/templates-manager.ts
@@ -42,7 +42,7 @@ class TemplatesManager {
     this._templatesStore = templatesStore;
   }
 
-  public add(name: string, template: ITemplate) {
+  public add(name: string, template: ITemplate): void {
     this._templatesContent[name] = template.content;
     const contentCreator = contentCreators[template.type]
       .bind(this, () => this._templatesContent[name]);

--- a/src/core/templates-renderer.tsx
+++ b/src/core/templates-renderer.tsx
@@ -6,7 +6,7 @@ import { TemplatesStore } from './templates-store';
 class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesStore }> {
   private _updateScheduled = false;
 
-  public scheduleUpdate() {
+  public scheduleUpdate(): void {
     if (this._updateScheduled) {
       return;
     }
@@ -19,7 +19,7 @@ class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesS
     });
   }
 
-  public render() {
+  public render(): React.ReactNode {
     const { templatesStore } = this.props;
     return React.createElement(
       React.Fragment,

--- a/src/core/widget-config.ts
+++ b/src/core/widget-config.ts
@@ -3,6 +3,10 @@ import { ITemplateMeta } from './template';
 const elementPropNames = ['style', 'id'];
 const classNamePropName = 'className';
 
+function isIgnoredProp(name: string) {
+  return name === 'children' || name === classNamePropName || elementPropNames.indexOf(name) > -1;
+}
+
 function separateProps(
   props: Record<string, any>,
   defaultsProps: Record<string, string>,
@@ -47,10 +51,6 @@ function separateProps(
 
 function getClassName(props: Record<string, any>): string | undefined {
   return props[classNamePropName];
-}
-
-function isIgnoredProp(name: string) {
-  return name === 'children' || name === classNamePropName || elementPropNames.indexOf(name) > -1;
 }
 
 export {

--- a/tools/src/component-generator.ts
+++ b/tools/src/component-generator.ts
@@ -75,8 +75,8 @@ const TYPE_KEY_FN = '(data: any) => string';
 const TYPE_RENDER = '(...params: any) => React.ReactNode';
 const TYPE_COMPONENT = 'React.ComponentType<any>';
 
-function generateReExport(path: string, fileName: string): string {
-  return renderReExport({ path, fileName });
+function getIndent(indent: number) {
+  return Array(indent * 2 + 1).join(' ');
 }
 
 const renderReExport: (model: { path: string, fileName: string }) => string = createTempate(
@@ -84,6 +84,297 @@ const renderReExport: (model: { path: string, fileName: string }) => string = cr
 + 'export * from "<#= it.path #>";\n'
 + 'export { default } from "<#= it.path #>";\n',
 );
+
+function generateReExport(path: string, fileName: string): string {
+  return renderReExport({ path, fileName });
+}
+
+const renderObjectEntry: (model: {
+  key: string;
+  value: string;
+}) => string = createTempate(`
+    <#= it.key #>: "<#= it.value #>"
+`.trimRight());
+
+function renderObject(props: IOption[], indent: number): string {
+  let result = '{';
+
+  indent += 1;
+
+  props.forEach((opt) => {
+    result += `\n${getIndent(indent)}${opt.name}?: `;
+    if (opt.nested && isNotEmptyArray(opt.nested)) {
+      result += renderObject(opt.nested, indent);
+      if (opt.isArray) { result += '[]'; }
+    } else {
+      result += opt.type;
+    }
+    result += ';';
+  });
+
+  indent -= 1;
+  result += `\n${getIndent(indent)}}`;
+  return result;
+}
+
+const renderTemplateOption: (model: {
+  actualOptionName: string;
+  render: string;
+  component: string;
+}) => string = createTempate(`
+  {
+    tmplOption: "<#= it.actualOptionName #>",
+    render: "<#= it.render #>",
+    component: "<#= it.component #>",
+    keyFn: "<#= it.keyFn #>"
+  }
+`.trim());
+
+const renderPropTyping: (model: IRenderedPropTyping) => string = createTempate(
+  '  <#= it.propName #>: '
+
++ '<#? it.renderedTypes.length === 1 #>'
+    + '<#= it.renderedTypes[0] #>'
+
++ '<#??#>'
+
+    + 'PropTypes.oneOfType([\n'
+    + '    <#= it.renderedTypes.join(\',\\n    \') #>\n'
+    + '  ])'
++ '<#?#>',
+);
+
+const renderModule: (model: {
+  renderedImports: string;
+  renderedOptionsInterface?: string;
+  renderedComponent: string;
+  renderedNestedComponents?: string[];
+  defaultExport: string;
+  renderedExports: string;
+}) => string = createTempate(
+  '<#= it.renderedImports #>\n'
+
++ '<#? it.renderedOptionsInterface #>'
+    + '<#= it.renderedOptionsInterface #>\n\n'
++ '<#?#>'
+
++ '<#= it.renderedComponent #>'
+
++ '<#? it.renderedNestedComponents #>'
+    + '<#~ it.renderedNestedComponents :nestedComponent #>\n\n'
+        + '<#= nestedComponent #>'
+    + '<#~#>\n\n'
++ '<#?#>'
+
++ 'export default <#= it.defaultExport #>;\n'
++ `export {
+<#= it.renderedExports #>
+};
+`,
+);
+
+const renderImports: (model: {
+  dxExportPath: string;
+  baseComponentPath: string;
+  baseComponentName: string;
+  widgetName: string;
+  optionsAliasName?: string;
+  hasExtraOptions: boolean;
+  hasPropTypings: boolean;
+  configComponentPath?: string;
+}) => string = createTempate(
+  'import <#= it.widgetName #>, {\n'
++ '    IOptions<#? it.optionsAliasName #> as <#= it.optionsAliasName #><#?#>\n'
++ '} from "<#= it.dxExportPath #>";\n\n'
+
++ '<#? it.hasPropTypings #>'
+    + 'import * as PropTypes from "prop-types";\n'
++ '<#?#>'
+
++ 'import { <#= it.baseComponentName #> as BaseComponent'
+    + '<#? it.hasExtraOptions #>'
+        + ', IHtmlOptions'
+    + '<#?#>'
++ ' } from "<#= it.baseComponentPath #>";\n'
+
++ '<#? it.configComponentPath #>'
+    + 'import NestedOption from "<#= it.configComponentPath #>";\n'
++ '<#?#>',
+);
+
+const renderNestedComponent: (model: {
+  className: string;
+  propsType: string;
+  optionName: string;
+  isCollectionItem?: boolean;
+  predefinedProps?: Array<{
+    name: string;
+    value: any;
+  }>;
+  expectedChildren?: IExpectedChild[];
+  renderedType: string;
+  renderedSubscribableOptions?: string[];
+  renderedTemplateProps?: string[];
+  owners: string[];
+}) => string = createTempate(
+  `${'// owners:\n'
++ '<#~ it.owners : owner #>'
+    + '// <#= owner #>\n'
++ '<#~#>'
+
++ 'interface <#= it.propsType #> <#= it.renderedType #>\n'
+
++ 'class <#= it.className #> extends NestedOption<<#= it.propsType #>> {'}${
+    L1}public static OptionName = "<#= it.optionName #>";`
+
++ `<#? it.isCollectionItem #>${
+  L1}public static IsCollectionItem = true;`
++ '<#?#>'
+
++ `<#? it.renderedSubscribableOptions #>${
+  L1}public static DefaultsProps = {<#= it.renderedSubscribableOptions.join(',') #>${
+  L1}};`
++ '<#?#>'
+
++ `<#? it.expectedChildren #>${
+  L1}public static ExpectedChildren = {`
+
+    + `<#~ it.expectedChildren : child #>${
+      L2}<#= child.componentName #>:`
+        + ' { optionName: "<#= child.optionName #>", isCollectionItem: <#= !!child.isCollectionItem #> },'
+    + `<#~#>\b${
+
+      L1}};`
++ '<#?#>'
+
++ `<#? it.renderedTemplateProps #>${
+  L1}public static TemplateProps = [<#= it.renderedTemplateProps.join(', ') #>];`
++ '<#?#>'
+
++ `<#? it.predefinedProps #>${
+  L1}public static PredefinedProps = {`
+        + `<#~ it.predefinedProps : prop #>${
+          L2}<#= prop.name #>: "<#= prop.value #>",`
+        + `<#~#>\b${
+          L1}};`
++ '<#?#>'
+
++ '\n}',
+);
+
+const renderOptionsInterface: (model: {
+  optionsName: string;
+  templates: Array<{
+    render: string;
+    component: string;
+  }>;
+  defaultProps: Array<{
+    name: string;
+    type: string;
+  }>;
+  onChangeEvents: Array<{
+    name: string;
+    type: string;
+  }>;
+}) => string = createTempate(
+  'interface <#= it.optionsName #> extends IOptions, IHtmlOptions {\n'
+
++ '<#~ it.templates :template #>'
+    + `  <#= template.render #>?: ${TYPE_RENDER};\n`
+    + `  <#= template.component #>?: ${TYPE_COMPONENT};\n`
+    + `  <#= template.keyFn #>?: ${TYPE_KEY_FN};\n`
++ '<#~#>'
+
++ '<#~ it.defaultProps :prop #>'
+    + '  <#= prop.name #>?: <#= prop.type #>;\n'
++ '<#~#>'
+
++ '<#~ it.onChangeEvents :prop #>'
+    + '  <#= prop.name #>?: <#= prop.type #>;\n'
++ '<#~#>'
+
++ '}',
+);
+
+const renderComponent: (model: {
+  className: string;
+  widgetName: string;
+  optionsName: string;
+  expectedChildren?: IExpectedChild[];
+  renderedDefaultProps?: string[];
+  renderedTemplateProps?: string[];
+  renderedPropTypings?: string[];
+}) => string = createTempate(
+  `${`class <#= it.className #> extends BaseComponent<<#= it.optionsName #>> {
+
+  public get instance(): <#= it.widgetName #> {
+    return this._instance;
+  }
+
+  protected _WidgetClass = <#= it.widgetName #>;\n`
+
++ '<#? it.renderedDefaultProps #>'}${
+    L1}protected _defaults = {<#= it.renderedDefaultProps.join(',') #>${
+    L1}};\n`
++ '<#?#>'
+
++ `<#? it.expectedChildren #>${
+  L1}protected _expectedChildren = {`
+
++ `<#~ it.expectedChildren : child #>${
+  L2}<#= child.componentName #>:`
+    + ' { optionName: "<#= child.optionName #>", isCollectionItem: <#= !!child.isCollectionItem #> },'
++ `<#~#>\b${
+
+  L1}};\n`
++ '<#?#>'
+
++ `<#? it.renderedTemplateProps #>
+  protected _templateProps = [<#= it.renderedTemplateProps.join(', ') #>];
+<#?#>}\n`
+
++ '<#? it.renderedPropTypings #>'
+    + '(<#= it.className #> as any).propTypes = {\n'
+        + '<#= it.renderedPropTypings.join(\',\\n\') #>\n'
+    + '};\n'
++ '<#?#>',
+);
+
+function renderExports(exportsNames: string[]) {
+  return exportsNames
+    .map((exportName) => getIndent(1) + exportName)
+    .join(',\n');
+}
+
+function formatTemplatePropName(name: string, suffix: string): string {
+  return lowercaseFirst(name.replace(/template$/i, suffix));
+}
+
+function createTemplateDto(templates: string[] | undefined) {
+  return templates
+    ? templates.map((actualOptionName) => ({
+      actualOptionName,
+      render: formatTemplatePropName(actualOptionName, 'Render'),
+      component: formatTemplatePropName(actualOptionName, 'Component'),
+      keyFn: formatTemplatePropName(actualOptionName, 'KeyFn'),
+    }))
+    : undefined;
+}
+
+function buildPropsTypeName(className: string) {
+  return `I${className}Props`;
+}
+
+function createPropTypingModel(typing: IPropTyping): IRenderedPropTyping {
+  const types = typing.types.map((t) => `PropTypes.${t}`);
+  if (typing.acceptableValues && isNotEmptyArray(typing.acceptableValues)) {
+    types.push(`PropTypes.oneOf([\n    ${typing.acceptableValues.join(',\n    ')}\n  ])`);
+  }
+  return {
+    propName: typing.propName,
+    renderedTypes: types,
+  };
+}
 
 function generate(component: IComponent): string {
   const nestedComponents = component.nestedComponents
@@ -233,297 +524,6 @@ function generate(component: IComponent): string {
     defaultExport: component.name,
     renderedExports: renderExports(exportNames),
   });
-}
-
-function buildPropsTypeName(className: string) {
-  return `I${className}Props`;
-}
-
-function createTemplateDto(templates: string[] | undefined) {
-  return templates
-    ? templates.map((actualOptionName) => ({
-      actualOptionName,
-      render: formatTemplatePropName(actualOptionName, 'Render'),
-      component: formatTemplatePropName(actualOptionName, 'Component'),
-      keyFn: formatTemplatePropName(actualOptionName, 'KeyFn'),
-    }))
-    : undefined;
-}
-
-function formatTemplatePropName(name: string, suffix: string): string {
-  return lowercaseFirst(name.replace(/template$/i, suffix));
-}
-
-function createPropTypingModel(typing: IPropTyping): IRenderedPropTyping {
-  const types = typing.types.map((t) => `PropTypes.${t}`);
-  if (typing.acceptableValues && isNotEmptyArray(typing.acceptableValues)) {
-    types.push(`PropTypes.oneOf([\n    ${typing.acceptableValues.join(',\n    ')}\n  ])`);
-  }
-  return {
-    propName: typing.propName,
-    renderedTypes: types,
-  };
-}
-
-const renderModule: (model: {
-  renderedImports: string;
-  renderedOptionsInterface?: string;
-  renderedComponent: string;
-  renderedNestedComponents?: string[];
-  defaultExport: string;
-  renderedExports: string;
-}) => string = createTempate(
-  '<#= it.renderedImports #>\n'
-
-+ '<#? it.renderedOptionsInterface #>'
-    + '<#= it.renderedOptionsInterface #>\n\n'
-+ '<#?#>'
-
-+ '<#= it.renderedComponent #>'
-
-+ '<#? it.renderedNestedComponents #>'
-    + '<#~ it.renderedNestedComponents :nestedComponent #>\n\n'
-        + '<#= nestedComponent #>'
-    + '<#~#>\n\n'
-+ '<#?#>'
-
-+ 'export default <#= it.defaultExport #>;\n'
-+ `export {
-<#= it.renderedExports #>
-};
-`,
-);
-
-const renderImports: (model: {
-  dxExportPath: string;
-  baseComponentPath: string;
-  baseComponentName: string;
-  widgetName: string;
-  optionsAliasName?: string;
-  hasExtraOptions: boolean;
-  hasPropTypings: boolean;
-  configComponentPath?: string;
-}) => string = createTempate(
-  'import <#= it.widgetName #>, {\n'
-+ '    IOptions<#? it.optionsAliasName #> as <#= it.optionsAliasName #><#?#>\n'
-+ '} from "<#= it.dxExportPath #>";\n\n'
-
-+ '<#? it.hasPropTypings #>'
-    + 'import * as PropTypes from "prop-types";\n'
-+ '<#?#>'
-
-+ 'import { <#= it.baseComponentName #> as BaseComponent'
-    + '<#? it.hasExtraOptions #>'
-        + ', IHtmlOptions'
-    + '<#?#>'
-+ ' } from "<#= it.baseComponentPath #>";\n'
-
-+ '<#? it.configComponentPath #>'
-    + 'import NestedOption from "<#= it.configComponentPath #>";\n'
-+ '<#?#>',
-);
-
-const renderOptionsInterface: (model: {
-  optionsName: string;
-  templates: Array<{
-    render: string;
-    component: string;
-  }>;
-  defaultProps: Array<{
-    name: string;
-    type: string;
-  }>;
-  onChangeEvents: Array<{
-    name: string;
-    type: string;
-  }>;
-}) => string = createTempate(
-  'interface <#= it.optionsName #> extends IOptions, IHtmlOptions {\n'
-
-+ '<#~ it.templates :template #>'
-    + `  <#= template.render #>?: ${TYPE_RENDER};\n`
-    + `  <#= template.component #>?: ${TYPE_COMPONENT};\n`
-    + `  <#= template.keyFn #>?: ${TYPE_KEY_FN};\n`
-+ '<#~#>'
-
-+ '<#~ it.defaultProps :prop #>'
-    + '  <#= prop.name #>?: <#= prop.type #>;\n'
-+ '<#~#>'
-
-+ '<#~ it.onChangeEvents :prop #>'
-    + '  <#= prop.name #>?: <#= prop.type #>;\n'
-+ '<#~#>'
-
-+ '}',
-);
-
-const renderComponent: (model: {
-  className: string;
-  widgetName: string;
-  optionsName: string;
-  expectedChildren?: IExpectedChild[];
-  renderedDefaultProps?: string[];
-  renderedTemplateProps?: string[];
-  renderedPropTypings?: string[];
-}) => string = createTempate(
-  `${`class <#= it.className #> extends BaseComponent<<#= it.optionsName #>> {
-
-  public get instance(): <#= it.widgetName #> {
-    return this._instance;
-  }
-
-  protected _WidgetClass = <#= it.widgetName #>;\n`
-
-+ '<#? it.renderedDefaultProps #>'}${
-    L1}protected _defaults = {<#= it.renderedDefaultProps.join(',') #>${
-    L1}};\n`
-+ '<#?#>'
-
-+ `<#? it.expectedChildren #>${
-  L1}protected _expectedChildren = {`
-
-+ `<#~ it.expectedChildren : child #>${
-  L2}<#= child.componentName #>:`
-    + ' { optionName: "<#= child.optionName #>", isCollectionItem: <#= !!child.isCollectionItem #> },'
-+ `<#~#>\b${
-
-  L1}};\n`
-+ '<#?#>'
-
-+ `<#? it.renderedTemplateProps #>
-  protected _templateProps = [<#= it.renderedTemplateProps.join(', ') #>];
-<#?#>}\n`
-
-+ '<#? it.renderedPropTypings #>'
-    + '(<#= it.className #> as any).propTypes = {\n'
-        + '<#= it.renderedPropTypings.join(\',\\n\') #>\n'
-    + '};\n'
-+ '<#?#>',
-);
-
-const renderNestedComponent: (model: {
-  className: string;
-  propsType: string;
-  optionName: string;
-  isCollectionItem?: boolean;
-  predefinedProps?: Array<{
-    name: string;
-    value: any;
-  }>;
-  expectedChildren?: IExpectedChild[];
-  renderedType: string;
-  renderedSubscribableOptions?: string[];
-  renderedTemplateProps?: string[];
-  owners: string[];
-}) => string = createTempate(
-  `${'// owners:\n'
-+ '<#~ it.owners : owner #>'
-    + '// <#= owner #>\n'
-+ '<#~#>'
-
-+ 'interface <#= it.propsType #> <#= it.renderedType #>\n'
-
-+ 'class <#= it.className #> extends NestedOption<<#= it.propsType #>> {'}${
-    L1}public static OptionName = "<#= it.optionName #>";`
-
-+ `<#? it.isCollectionItem #>${
-  L1}public static IsCollectionItem = true;`
-+ '<#?#>'
-
-+ `<#? it.renderedSubscribableOptions #>${
-  L1}public static DefaultsProps = {<#= it.renderedSubscribableOptions.join(',') #>${
-  L1}};`
-+ '<#?#>'
-
-+ `<#? it.expectedChildren #>${
-  L1}public static ExpectedChildren = {`
-
-    + `<#~ it.expectedChildren : child #>${
-      L2}<#= child.componentName #>:`
-        + ' { optionName: "<#= child.optionName #>", isCollectionItem: <#= !!child.isCollectionItem #> },'
-    + `<#~#>\b${
-
-      L1}};`
-+ '<#?#>'
-
-+ `<#? it.renderedTemplateProps #>${
-  L1}public static TemplateProps = [<#= it.renderedTemplateProps.join(', ') #>];`
-+ '<#?#>'
-
-+ `<#? it.predefinedProps #>${
-  L1}public static PredefinedProps = {`
-        + `<#~ it.predefinedProps : prop #>${
-          L2}<#= prop.name #>: "<#= prop.value #>",`
-        + `<#~#>\b${
-          L1}};`
-+ '<#?#>'
-
-+ '\n}',
-);
-
-const renderTemplateOption: (model: {
-  actualOptionName: string;
-  render: string;
-  component: string;
-}) => string = createTempate(`
-  {
-    tmplOption: "<#= it.actualOptionName #>",
-    render: "<#= it.render #>",
-    component: "<#= it.component #>",
-    keyFn: "<#= it.keyFn #>"
-  }
-`.trim());
-
-const renderPropTyping: (model: IRenderedPropTyping) => string = createTempate(
-  '  <#= it.propName #>: '
-
-+ '<#? it.renderedTypes.length === 1 #>'
-    + '<#= it.renderedTypes[0] #>'
-
-+ '<#??#>'
-
-    + 'PropTypes.oneOfType([\n'
-    + '    <#= it.renderedTypes.join(\',\\n    \') #>\n'
-    + '  ])'
-+ '<#?#>',
-);
-
-const renderObjectEntry: (model: {
-  key: string;
-  value: string;
-}) => string = createTempate(`
-    <#= it.key #>: "<#= it.value #>"
-`.trimRight());
-
-function renderObject(props: IOption[], indent: number): string {
-  let result = '{';
-
-  indent += 1;
-
-  props.forEach((opt) => {
-    result += `\n${getIndent(indent)}${opt.name}?: `;
-    if (opt.nested && isNotEmptyArray(opt.nested)) {
-      result += renderObject(opt.nested, indent);
-      if (opt.isArray) { result += '[]'; }
-    } else {
-      result += opt.type;
-    }
-    result += ';';
-  });
-
-  indent -= 1;
-  result += `\n${getIndent(indent)}}`;
-  return result;
-}
-
-function getIndent(indent: number) {
-  return Array(indent * 2 + 1).join(' ');
-}
-
-function renderExports(exportsNames: string[]) {
-  return exportsNames
-    .map((exportName) => getIndent(1) + exportName)
-    .join(',\n');
 }
 
 export default generate;

--- a/tools/src/converter.ts
+++ b/tools/src/converter.ts
@@ -1,25 +1,14 @@
 import { ICustomType, ITypeDescr } from '../integration-data-model';
 import { lowercaseFirst } from './helpers';
 
-function convertTypes(
-  types: ITypeDescr[] | undefined | null,
-  customTypes?: Record<string, ICustomType>,
-): string[] | undefined {
-  if (types === undefined || types === null || types.length === 0) {
-    return undefined;
-  }
-
-  if (customTypes) {
-    types.push(...expandTypes(types, customTypes));
-  }
-
-  const convertedTypes = new Set(types.map(convertType));
-  if (convertedTypes.has('Any')) {
-    return undefined;
-  }
-
-  return Array.from(convertedTypes);
-}
+const inputTypes = {
+  array: 'Array',
+  string: 'String',
+  number: 'Number',
+  object: 'Object',
+  bool: 'Boolean',
+  func: 'Function',
+};
 
 function expandTypes(types: ITypeDescr[], customTypes: Record<string, ICustomType>): ITypeDescr[] {
   const expandedTypes: ITypeDescr[] = [];
@@ -59,14 +48,25 @@ function convertType(typeDescr: ITypeDescr): string {
   return 'Any';
 }
 
-const inputTypes = {
-  array: 'Array',
-  string: 'String',
-  number: 'Number',
-  object: 'Object',
-  bool: 'Boolean',
-  func: 'Function',
-};
+function convertTypes(
+  types: ITypeDescr[] | undefined | null,
+  customTypes?: Record<string, ICustomType>,
+): string[] | undefined {
+  if (types === undefined || types === null || types.length === 0) {
+    return undefined;
+  }
+
+  if (customTypes) {
+    types.push(...expandTypes(types, customTypes));
+  }
+
+  const convertedTypes = new Set(types.map(convertType));
+  if (convertedTypes.has('Any')) {
+    return undefined;
+  }
+
+  return Array.from(convertedTypes);
+}
 
 export {
   convertTypes,

--- a/tools/src/generator.ts
+++ b/tools/src/generator.ts
@@ -185,7 +185,7 @@ function generate({
     indexFileName: string
   },
   widgetsPackage: string
-}) {
+}): void {
   const modulePaths: IReExport[] = [];
 
   rawData.widgets.forEach((data) => {

--- a/tools/src/helpers.ts
+++ b/tools/src/helpers.ts
@@ -36,12 +36,12 @@ export function removeElement<T>(array: T[], element: T) {
   }
 }
 
-export function isNotEmptyArray(array: any[] | undefined | null): boolean {
-  return !isEmptyArray(array);
-}
-
 export function isEmptyArray(array: any[] | undefined | null): boolean {
   return array === undefined || array === null || array.length === 0;
+}
+
+export function isNotEmptyArray(array: any[] | undefined | null): boolean {
+  return !isEmptyArray(array);
 }
 
 export function isPlainObject(value: any): boolean {

--- a/tools/src/helpers.ts
+++ b/tools/src/helpers.ts
@@ -1,7 +1,7 @@
 import * as dasherize from 'dasherize';
 import { extname as getPathExtension } from 'path';
 
-export function removeExtension(path: string) {
+export function removeExtension(path: string): string {
   return path.slice(0, -getPathExtension(path).length);
 }
 
@@ -26,10 +26,10 @@ export function compareStrings(a: string, b: string): number {
 }
 
 export function createKeyComparator<T>(keyGetter: (x: T) => string) {
-  return (a: T, b: T) => compareStrings(keyGetter(a), keyGetter(b));
+  return (a: T, b: T): number => compareStrings(keyGetter(a), keyGetter(b));
 }
 
-export function removeElement<T>(array: T[], element: T) {
+export function removeElement<T>(array: T[], element: T): void {
   const index = array.indexOf(element);
   if (index > -1) {
     array.splice(index, 1);

--- a/tools/src/helpers.ts
+++ b/tools/src/helpers.ts
@@ -44,6 +44,6 @@ export function isNotEmptyArray(array: any[] | undefined | null): boolean {
   return !isEmptyArray(array);
 }
 
-export function isPlainObject(value: any): boolean {
+export function isPlainObject(value: Record<string, any>): boolean {
   return value.constructor === Object;
 }

--- a/tools/src/index-generator.test.ts
+++ b/tools/src/index-generator.test.ts
@@ -1,5 +1,12 @@
 import generate from './index-generator';
 
+// #region EXPECTED_GENERATES
+const EXPECTED_GENERATES = `
+export { Template } from "./core/template";
+export { widget } from "./path";
+export { anotherWidget } from "./another/path";
+`.trimLeft();
+
 it('generates', () => {
   expect(
     generate([
@@ -8,9 +15,3 @@ it('generates', () => {
     ]),
   ).toBe(EXPECTED_GENERATES);
 });
-// #region EXPECTED_GENERATES
-const EXPECTED_GENERATES = `
-export { Template } from "./core/template";
-export { widget } from "./path";
-export { anotherWidget } from "./another/path";
-`.trimLeft();

--- a/tools/src/index-generator.ts
+++ b/tools/src/index-generator.ts
@@ -8,14 +8,14 @@ interface IReExport {
 const constParts = `export { Template } from "./core/template";
 `;
 
-function generate(paths: IReExport[]): string {
-  return constParts.concat(render(paths));
-}
-
 const render: (model: IReExport[]) => string = createTempate(`
 <#~ it :reExport #>export { <#= reExport.name #> } from "<#= reExport.path #>";
 <#~#>
 `.trim());
+
+function generate(paths: IReExport[]): string {
+  return constParts.concat(render(paths));
+}
 
 export default generate;
 export {

--- a/tools/src/template.ts
+++ b/tools/src/template.ts
@@ -23,6 +23,10 @@ const createTempate = (templateStr: string): ((model: any) => string) => {
     .replace(/\x08/, '');
 };
 
+function tab(i: number): string {
+  return Array(i * 2 + 1).join(' ');
+}
+
 const L1 = `\n${tab(1)}`;
 const L2 = `\n${tab(2)}`;
 const L3 = `\n${tab(3)}`;
@@ -32,10 +36,6 @@ const TAB1: string = tab(1);
 const TAB2: string = tab(2);
 const TAB3: string = tab(3);
 const TAB4: string = tab(4);
-
-function tab(i: number): string {
-  return Array(i * 2 + 1).join(' ');
-}
 
 export {
   createTempate,


### PR DESCRIPTION
fix

@typescript-eslint/no-use-before-define
@typescript-eslint/no-shadow
@typescript-eslint/explicit-module-boundary-types : return types
jsx-a11y/no-static-element-interactions
jsx-a11y/click-events-have-key-events
import/no-named-as-default
import/no-extraneous-dependencies
no-alert