### PR TITLE
Prevent "onXXXChange" call in JS for non-subscribable options

### DIFF
--- a/src/core/__tests__/props-updating.test.tsx
+++ b/src/core/__tests__/props-updating.test.tsx
@@ -816,7 +816,7 @@ describe('onXXXChange', () => {
     });
   });
 
-  describe('unsubscribable options', () => {
+  describe('non-subscribable options', () => {
     beforeAll(() => {
       jest.spyOn(
           OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },

--- a/src/core/__tests__/props-updating.test.tsx
+++ b/src/core/__tests__/props-updating.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import ConfigurationComponent from '../nested-option';
+import { OptionsManager } from '../options-manager';
 import { mount, React, shallow } from './setup';
 import {
   eventHandlers,
@@ -624,6 +625,18 @@ describe('mutation detection', () => {
 });
 
 describe('onXXXChange', () => {
+  let isSubscribable;
+  beforeEach(() => {
+    isSubscribable = jest
+      .spyOn(
+        OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },
+        'isOptionSubscribable',
+      ).mockImplementation(() => true);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('is called on component changes controlled option', () => {
     const onPropChange = jest.fn();
     const component = mount(
@@ -776,5 +789,20 @@ describe('onXXXChange', () => {
     );
 
     expect(() => fireOptionChange('text', '1')).toThrow();
+  });
+
+  it('is not called if option is not subscribable', () => {
+    const onPropChange = jest.fn();
+    isSubscribable.mockImplementation(() => false);
+    mount(
+      <TestComponent
+        text="0"
+        onTextChange={onPropChange}
+      />,
+    );
+
+    expect(onPropChange).toHaveBeenCalledTimes(0);
+    fireOptionChange('text', '1');
+    expect(onPropChange).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/core/__tests__/props-updating.test.tsx
+++ b/src/core/__tests__/props-updating.test.tsx
@@ -625,184 +625,231 @@ describe('mutation detection', () => {
 });
 
 describe('onXXXChange', () => {
-  let isSubscribable;
-  beforeEach(() => {
-    isSubscribable = jest
-      .spyOn(
-        OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },
-        'isOptionSubscribable',
-      ).mockImplementation(() => true);
-  });
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  describe('subscribable options', () => {
+    beforeAll(() => {
+      jest.spyOn(
+          OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },
+          'isOptionSubscribable')
+        .mockImplementation(() => true);
+    });
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+    
+    it('is not called on create', () => {
+      const onPropChange = jest.fn();
+      mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
 
-  it('is called on component changes controlled option', () => {
-    const onPropChange = jest.fn();
-    const component = mount(
-      <TestComponent
-        text="0"
-        onTextChange={onPropChange}
-      />,
-    );
-    expect(onPropChange).not.toBeCalled();
+      expect(onPropChange).toHaveBeenCalledTimes(0);
+    });
+  
+    it('is called on update', () => {
+      const onPropChange = jest.fn();
+      mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
 
-    const sampleProps = { text: '1' };
-    component.setProps(sampleProps);
-    expect(onPropChange).not.toBeCalled();
-
-    fireOptionChange('text', '2');
-    expect(onPropChange).toHaveBeenCalledTimes(1);
-    expect(onPropChange).toBeCalledWith('2');
-
-    fireOptionChange('text', '3');
-    expect(onPropChange).toHaveBeenCalledTimes(2);
-    expect(onPropChange).toBeCalledWith('3');
-  });
-
-  it('is not called if received value is being modified', () => {
-    const onPropChange = jest.fn();
-    const component = mount(
-      <TestComponent
-        text="0"
-        onTextChange={onPropChange}
-      />,
-    );
-    onPropChange.mockImplementation((value) => {
-      component.setProps({ text: `X${value}` });
+      fireOptionChange('text', '1');
+      expect(onPropChange).toHaveBeenCalledTimes(1);
     });
 
-    fireOptionChange('text', '2');
-    expect(onPropChange).toHaveBeenCalledTimes(1);
-    expect(component.prop('text')).toBe('X2');
-
-    fireOptionChange('text', 'X22');
-    expect(onPropChange).toHaveBeenCalledTimes(2);
-    expect(component.prop('text')).toBe('XX22');
-  });
-
-  it('is not called if new value is equal', () => {
-    const onPropChange = jest.fn();
-    mount(
-      <TestComponent
-        text="0"
-        onTextChange={onPropChange}
-      />,
-    );
-
-    fireOptionChange('text', '0');
-    expect(onPropChange).toHaveBeenCalledTimes(0);
-  });
-
-  it('is called on component changes complex option', () => {
-    const onPropChange = jest.fn();
-    mount(
-      <TestComponent
-        complexOption={{ text: '0', onTextChange: onPropChange }}
-      />,
-    );
-    expect(onPropChange).not.toBeCalled();
-
-    fireOptionChange('complexOption.text', '1');
-    expect(onPropChange).toHaveBeenCalledTimes(1);
-    expect(onPropChange).toBeCalledWith('1');
-  });
-
-  it('is called on component changes array option', () => {
-    const onFirstPropChange = jest.fn();
-    const onSecondPropChange = jest.fn();
-    mount(
-      <TestComponent
-        arrayOption={[
-          { text: '0', onTextChange: onFirstPropChange },
-          { text: '0', onTextChange: onSecondPropChange },
-        ]}
-      />,
-    );
-    expect(onFirstPropChange).not.toBeCalled();
-    expect(onSecondPropChange).not.toBeCalled();
-
-    fireOptionChange('arrayOption[0].text', '1');
-    expect(onFirstPropChange).toHaveBeenCalledTimes(1);
-    expect(onSecondPropChange).not.toBeCalled();
-    expect(onFirstPropChange).toHaveBeenCalledWith('1');
-
-    fireOptionChange('arrayOption[1].text', '2');
-    expect(onFirstPropChange).toHaveBeenCalledTimes(1);
-    expect(onSecondPropChange).toHaveBeenCalledTimes(1);
-    expect(onSecondPropChange).toHaveBeenCalledWith('2');
-  });
-
-  it('is called on nested option changed', () => {
-    const onNestedPropChange = jest.fn();
-    const onSubNestedPropChange = jest.fn();
-    const onCollectionPropChange = jest.fn();
-    const onSubCollectionPropChange = jest.fn();
-    mount(
-      <TestComponent>
-        <NestedComponent
-          value={0}
-          onValueChange={onNestedPropChange}
-        />
-        <CollectionNestedComponent
-          a={0}
-        />
-        <CollectionNestedComponent
-          a={0}
-          onAChange={onCollectionPropChange}
-        >
-          <CollectionSubNestedComponent
-            a={0}
-            onAChange={onSubCollectionPropChange}
-          />
+    it('is called on component changes controlled option', () => {
+      const onPropChange = jest.fn();
+      const component = mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
+      expect(onPropChange).not.toBeCalled();
+  
+      const sampleProps = { text: '1' };
+      component.setProps(sampleProps);
+      expect(onPropChange).not.toBeCalled();
+  
+      fireOptionChange('text', '2');
+      expect(onPropChange).toHaveBeenCalledTimes(1);
+      expect(onPropChange).toBeCalledWith('2');
+  
+      fireOptionChange('text', '3');
+      expect(onPropChange).toHaveBeenCalledTimes(2);
+      expect(onPropChange).toBeCalledWith('3');
+    });
+  
+    it('is not called if received value is being modified', () => {
+      const onPropChange = jest.fn();
+      const component = mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
+      onPropChange.mockImplementation((value) => {
+        component.setProps({ text: `X${value}` });
+      });
+  
+      fireOptionChange('text', '2');
+      expect(onPropChange).toHaveBeenCalledTimes(1);
+      expect(component.prop('text')).toBe('X2');
+  
+      fireOptionChange('text', 'X22');
+      expect(onPropChange).toHaveBeenCalledTimes(2);
+      expect(component.prop('text')).toBe('XX22');
+    });
+  
+    it('is not called if new value is equal', () => {
+      const onPropChange = jest.fn();
+      mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
+  
+      fireOptionChange('text', '0');
+      expect(onPropChange).toHaveBeenCalledTimes(0);
+    });
+  
+    it('is called on component changes complex option', () => {
+      const onPropChange = jest.fn();
+      mount(
+        <TestComponent
+          complexOption={{ text: '0', onTextChange: onPropChange }}
+        />,
+      );
+      expect(onPropChange).not.toBeCalled();
+  
+      fireOptionChange('complexOption.text', '1');
+      expect(onPropChange).toHaveBeenCalledTimes(1);
+      expect(onPropChange).toBeCalledWith('1');
+    });
+  
+    it('is called on component changes array option', () => {
+      const onFirstPropChange = jest.fn();
+      const onSecondPropChange = jest.fn();
+      mount(
+        <TestComponent
+          arrayOption={[
+            { text: '0', onTextChange: onFirstPropChange },
+            { text: '0', onTextChange: onSecondPropChange },
+          ]}
+        />,
+      );
+      expect(onFirstPropChange).not.toBeCalled();
+      expect(onSecondPropChange).not.toBeCalled();
+  
+      fireOptionChange('arrayOption[0].text', '1');
+      expect(onFirstPropChange).toHaveBeenCalledTimes(1);
+      expect(onSecondPropChange).not.toBeCalled();
+      expect(onFirstPropChange).toHaveBeenCalledWith('1');
+  
+      fireOptionChange('arrayOption[1].text', '2');
+      expect(onFirstPropChange).toHaveBeenCalledTimes(1);
+      expect(onSecondPropChange).toHaveBeenCalledTimes(1);
+      expect(onSecondPropChange).toHaveBeenCalledWith('2');
+    });
+  
+    it('is called on nested option changed', () => {
+      const onNestedPropChange = jest.fn();
+      const onSubNestedPropChange = jest.fn();
+      const onCollectionPropChange = jest.fn();
+      const onSubCollectionPropChange = jest.fn();
+      mount(
+        <TestComponent>
           <NestedComponent
             value={0}
-            onValueChange={onSubNestedPropChange}
+            onValueChange={onNestedPropChange}
           />
-        </CollectionNestedComponent>
-      </TestComponent>,
-    );
-
-    fireOptionChange('items[1].a', 1);
-    expect(onCollectionPropChange).toHaveBeenCalledTimes(1);
-    expect(onCollectionPropChange).toBeCalledWith(1);
-
-    fireOptionChange('items[1].subItems[0].a', 2);
-    expect(onSubCollectionPropChange).toHaveBeenCalledTimes(1);
-    expect(onSubCollectionPropChange).toBeCalledWith(2);
-
-    fireOptionChange('nestedOption.value', '3');
-    expect(onNestedPropChange).toHaveBeenCalledTimes(1);
-    expect(onNestedPropChange).toBeCalledWith('3');
-
-    fireOptionChange('items[1].nestedOption.value', '4');
-    expect(onSubNestedPropChange).toHaveBeenCalledTimes(1);
-    expect(onSubNestedPropChange).toBeCalledWith('4');
+          <CollectionNestedComponent
+            a={0}
+          />
+          <CollectionNestedComponent
+            a={0}
+            onAChange={onCollectionPropChange}
+          >
+            <CollectionSubNestedComponent
+              a={0}
+              onAChange={onSubCollectionPropChange}
+            />
+            <NestedComponent
+              value={0}
+              onValueChange={onSubNestedPropChange}
+            />
+          </CollectionNestedComponent>
+        </TestComponent>,
+      );
+  
+      fireOptionChange('items[1].a', 1);
+      expect(onCollectionPropChange).toHaveBeenCalledTimes(1);
+      expect(onCollectionPropChange).toBeCalledWith(1);
+  
+      fireOptionChange('items[1].subItems[0].a', 2);
+      expect(onSubCollectionPropChange).toHaveBeenCalledTimes(1);
+      expect(onSubCollectionPropChange).toBeCalledWith(2);
+  
+      fireOptionChange('nestedOption.value', '3');
+      expect(onNestedPropChange).toHaveBeenCalledTimes(1);
+      expect(onNestedPropChange).toBeCalledWith('3');
+  
+      fireOptionChange('items[1].nestedOption.value', '4');
+      expect(onSubNestedPropChange).toHaveBeenCalledTimes(1);
+      expect(onSubNestedPropChange).toBeCalledWith('4');
+    });
+  
+    it('throws an error if handler is not a function', () => {
+      mount(
+        <TestComponent
+          text="0"
+          onTextChange="someFunction"
+        />,
+      );
+  
+      expect(() => fireOptionChange('text', '1')).toThrow();
+    });
   });
 
-  it('throws an error if handler is not a function', () => {
-    mount(
-      <TestComponent
-        text="0"
-        onTextChange="someFunction"
-      />,
-    );
+  describe('unsubscribable options', () => {
+    beforeAll(() => {
+      jest.spyOn(
+          OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },
+          'isOptionSubscribable')
+        .mockImplementation(() => false);
+    });
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+  
+    it('is not called on create', () => {
+      const onPropChange = jest.fn();
+      mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
 
-    expect(() => fireOptionChange('text', '1')).toThrow();
-  });
+      expect(onPropChange).toHaveBeenCalledTimes(0);
+    });
+  
+    it('is not called on update', () => {
+      const onPropChange = jest.fn();
+      mount(
+        <TestComponent
+          text="0"
+          onTextChange={onPropChange}
+        />,
+      );
 
-  it('is not called if option is not subscribable', () => {
-    const onPropChange = jest.fn();
-    isSubscribable.mockImplementation(() => false);
-    mount(
-      <TestComponent
-        text="0"
-        onTextChange={onPropChange}
-      />,
-    );
-
-    expect(onPropChange).toHaveBeenCalledTimes(0);
-    fireOptionChange('text', '1');
-    expect(onPropChange).toHaveBeenCalledTimes(0);
+      fireOptionChange('text', '1');
+      expect(onPropChange).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/core/component-base.ts
+++ b/src/core/component-base.ts
@@ -33,6 +33,8 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
 
   protected readonly _expectedChildren: Record<string, IExpectedChild>;
 
+  protected readonly subscribableOptions: string[];
+
   private _templatesRendererRef: TemplatesRenderer | null;
 
   private _templatesStore: TemplatesStore;
@@ -93,7 +95,7 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
     );
 
     this._useDeferUpdateForTemplates = this._instance.option('integrationOptions.useDeferUpdateForTemplates');
-    this._optionsManager.setInstance(this._instance, config);
+    this._optionsManager.setInstance(this._instance, config, this.subscribableOptions);
     this._instance.on('optionChanged', this._optionsManager.onOptionChanged);
   }
 

--- a/src/core/options-manager.ts
+++ b/src/core/options-manager.ts
@@ -17,6 +17,8 @@ class OptionsManager {
 
   private currentConfig: IConfigNode;
 
+  private subscribableOptions: Set<string>;
+
   constructor(templatesManager: TemplatesManager) {
     this.templatesManager = templatesManager;
 
@@ -24,9 +26,14 @@ class OptionsManager {
     this.wrapOptionValue = this.wrapOptionValue.bind(this);
   }
 
-  public setInstance(instance: unknown, config: IConfigNode): void {
+  public setInstance(
+    instance: unknown,
+    config: IConfigNode,
+    subscribableOptions: string[],
+  ): void {
     this.instance = instance;
     this.currentConfig = config;
+    this.subscribableOptions = new Set(subscribableOptions);
   }
 
   public getInitialOptions(rootNode: IConfigNode): Record<string, unknown> {
@@ -124,7 +131,15 @@ class OptionsManager {
     });
   }
 
+  private isOptionSubscribable(optionName: string): boolean {
+    return this.subscribableOptions.has(optionName);
+  }
+
   private callOptionChangeHandler(optionName: string, optionValue: unknown) {
+    if (!this.isOptionSubscribable(optionName)) {
+      return;
+    }
+
     const parts = optionName.split('.');
     const propName = parts[parts.length - 1];
 

--- a/tools/src/component-generator.test.ts
+++ b/tools/src/component-generator.test.ts
@@ -254,6 +254,8 @@ class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
 
   protected _WidgetClass = dxCLASS_NAME;
 
+  protected subscribableOptions = ["option1"];
+
   protected _defaults = {
     defaultOption1: "option1"
   };
@@ -302,6 +304,8 @@ class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
   }
 
   protected _WidgetClass = dxCLASS_NAME;
+
+  protected subscribableOptions = ["option1","option2"];
 
   protected _defaults = {
     defaultOption1: "option1",

--- a/tools/src/component-generator.ts
+++ b/tools/src/component-generator.ts
@@ -130,6 +130,8 @@ const renderTemplateOption: (model: {
   }
 `.trim());
 
+const renderStringEntry: (value: string) => string = createTempate('"<#= it #>"');
+
 const renderPropTyping: (model: IRenderedPropTyping) => string = createTempate(
   '  <#= it.propName #>: '
 
@@ -300,12 +302,13 @@ const renderComponent: (model: {
   className: string;
   widgetName: string;
   optionsName: string;
+  subscribableOptions?: string[];
   expectedChildren?: IExpectedChild[];
   renderedDefaultProps?: string[];
   renderedTemplateProps?: string[];
   renderedPropTypings?: string[];
 }) => string = createTempate(
-  `${`class <#= it.className #> extends BaseComponent<<#= it.optionsName #>> {
+  `class <#= it.className #> extends BaseComponent<<#= it.optionsName #>> {
 
   public get instance(): <#= it.widgetName #> {
     return this._instance;
@@ -313,9 +316,13 @@ const renderComponent: (model: {
 
   protected _WidgetClass = <#= it.widgetName #>;\n`
 
-+ '<#? it.renderedDefaultProps #>'}${
-    L1}protected _defaults = {<#= it.renderedDefaultProps.join(',') #>${
-    L1}};\n`
++ `<#? it.subscribableOptions #>${
+  L1}protected subscribableOptions = [<#= it.subscribableOptions.join(',') #>];\n`
++ '<#?#>'
+
++ `<#? it.renderedDefaultProps #>${
+  L1}protected _defaults = {<#= it.renderedDefaultProps.join(',') #>${
+  L1}};\n`
 + '<#?#>'
 
 + `<#? it.expectedChildren #>${
@@ -510,6 +517,7 @@ function generate(component: IComponent): string {
       className: component.name,
       widgetName,
       optionsName,
+      subscribableOptions: component.subscribableOptions?.map((o) => renderStringEntry(o.name)),
       renderedTemplateProps: templates && templates.map(renderTemplateOption),
       renderedDefaultProps: defaultProps && defaultProps.map((o) => renderObjectEntry({
         key: o.name,


### PR DESCRIPTION
All subscribable options are collected (for prevent handler call in JS for non-subscribable options)