### PR TITLE
Refactor `displayContentsStyle` as static method instead static getter

### DIFF
--- a/packages/devextreme-react/src/core/component-base.ts
+++ b/packages/devextreme-react/src/core/component-base.ts
@@ -23,7 +23,7 @@ interface IHtmlOptions {
 }
 
 abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent<P> {
-  static get displayContentsStyle(): React.CSSProperties {
+  static displayContentsStyle(): React.CSSProperties {
     return isIE()
       ? {
         width: '100%',
@@ -189,7 +189,7 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
             this.forceUpdate();
           }
         },
-        style: ComponentBase.displayContentsStyle,
+        style: ComponentBase.displayContentsStyle(),
       })
       : this.renderChildren();
   }


### PR DESCRIPTION
Fixes issues with TypeScript configs in dependent products