### PR TITLE
Update properties generation

### DIFF
--- a/packages/devextreme-react-generator/src/component-generator.test.ts
+++ b/packages/devextreme-react-generator/src/component-generator.test.ts
@@ -4,12 +4,12 @@ it('generates', () => {
   // #region EXPECTED
   const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -42,7 +42,7 @@ it('generates extension component', () => {
   // #region EXPECTED
   const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions as ICLASS_NAMEOptions
+    Properties as ICLASS_NAMEOptions
 } from "DX/WIDGET/PATH";
 
 import { ExtensionComponent as BaseComponent } from "EXTENSION_COMPONENT_PATH";
@@ -74,17 +74,79 @@ export {
   ).toBe(EXPECTED);
 });
 
+describe('generic types clause', () => {
+  it('is generated', () => {
+    // #region EXPECTED
+    const EXPECTED = `
+import dxCLASS_NAME, {
+    Properties
+} from "DX/WIDGET/PATH";
+
+import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
+
+interface ICLASS_NAMEOptions<T1 = any, T2 = any> extends Properties<T1, T2>, IHtmlOptions {
+  dataSource?: Properties<T1, T2>["dataSource"];
+}
+
+class CLASS_NAME<T1, T2> extends BaseComponent<ICLASS_NAMEOptions<T1, T2>> {
+
+  public get instance(): dxCLASS_NAME {
+    return this._instance;
+  }
+
+  protected _WidgetClass = dxCLASS_NAME;
+}
+export default CLASS_NAME;
+export {
+  CLASS_NAME,
+  ICLASS_NAMEOptions
+};
+`.trimLeft();
+      // #endregion
+
+    expect(
+      generate({
+        name: 'CLASS_NAME',
+        baseComponentPath: 'BASE_COMPONENT_PATH',
+        extensionComponentPath: 'EXTENSION_COMPONENT_PATH',
+        dxExportPath: 'DX/WIDGET/PATH',
+        optionsTypeParams: ['T1', 'T2'],
+      }),
+    ).toBe(EXPECTED);
+  });
+
+  it('is not generated for empty parrams array', () => {
+    expect(
+      generate({
+        name: 'CLASS_NAME',
+        baseComponentPath: 'BASE_COMPONENT_PATH',
+        extensionComponentPath: 'EXTENSION_COMPONENT_PATH',
+        dxExportPath: 'DX/WIDGET/PATH',
+        optionsTypeParams: [],
+      }),
+    ).toBe(
+      generate({
+        name: 'CLASS_NAME',
+        baseComponentPath: 'BASE_COMPONENT_PATH',
+        extensionComponentPath: 'EXTENSION_COMPONENT_PATH',
+        dxExportPath: 'DX/WIDGET/PATH',
+        optionsTypeParams: [],
+      }),
+    );
+  });
+});
+
 describe('template-props generation', () => {
   it('processes option', () => {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
   optionRender?: (...params: any) => React.ReactNode;
   optionComponent?: React.ComponentType<any>;
   optionKeyFn?: (data: any) => string;
@@ -128,12 +190,12 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
   optionRender?: (...params: any) => React.ReactNode;
   optionComponent?: React.ComponentType<any>;
   optionKeyFn?: (data: any) => string;
@@ -185,12 +247,12 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
   render?: (...params: any) => React.ReactNode;
   component?: React.ComponentType<any>;
   keyFn?: (data: any) => string;
@@ -236,12 +298,12 @@ describe('props generation', () => {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
   defaultOption1?: someType;
   onOption1Change?: (value: someType) => void;
 }
@@ -285,12 +347,12 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
   defaultOption1?: someType;
   defaultOption2?: anotherType;
   onOption1Change?: (value: someType) => void;
@@ -338,12 +400,12 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
   defaultOption1?: someType;
   onOption1Change?: (value: someType) => void;
 }
@@ -391,13 +453,13 @@ describe('nested options', () => {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -505,13 +567,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -573,13 +635,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -658,13 +720,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -734,13 +796,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -807,13 +869,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -900,13 +962,13 @@ describe('prop typings', () => {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -948,13 +1010,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -1000,13 +1062,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -1051,13 +1113,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -1119,12 +1181,12 @@ describe('child expectation', () => {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {
@@ -1166,13 +1228,13 @@ export {
     // #region EXPECTED
     const EXPECTED = `
 import dxCLASS_NAME, {
-    IOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-interface ICLASS_NAMEOptions extends IOptions, IHtmlOptions {
+interface ICLASS_NAMEOptions extends Properties, IHtmlOptions {
 }
 
 class CLASS_NAME extends BaseComponent<ICLASS_NAMEOptions> {

--- a/packages/devextreme-react-generator/src/component-generator.ts
+++ b/packages/devextreme-react-generator/src/component-generator.ts
@@ -18,6 +18,7 @@ type IComponent = {
   independentEvents?: IIndependentEvents[],
   templates?: string[];
   propTypings?: IPropTyping[];
+  optionsTypeParams?: string[];
 } & {
   nestedComponents?: INestedComponent[];
   configComponentPath?: string;
@@ -205,7 +206,7 @@ const renderImports: (model: {
   configComponentPath?: string;
 }) => string = createTempate(
   'import <#= it.widgetName #>, {\n'
-+ '    IOptions<#? it.optionsAliasName #> as <#= it.optionsAliasName #><#?#>\n'
++ '    Properties<#? it.optionsAliasName #> as <#= it.optionsAliasName #><#?#>\n'
 + '} from "<#= it.dxExportPath #>";\n\n'
 
 + '<#? it.hasPropTypings #>'
@@ -283,8 +284,18 @@ const renderNestedComponent: (model: {
 + '\n}',
 );
 
+const TYPE_PARAMS = '<#? it.typeParams #>'
+    + '<<#= it.typeParams.join(", ") #>>'
++ '<#?#>';
+
+const TYPE_PARAMS_WITH_DEFAULTS = '<#? it.typeParams #>'
+    // eslint-disable-next-line no-template-curly-in-string
+    + '<<#= it.typeParams.map(p => `${p} = any`).join(", ") #>>'
++ '<#?#>';
+
 const renderOptionsInterface: (model: {
   optionsName: string;
+  typeParams: string[] | undefined;
   templates: Array<{
     render: string;
     component: string;
@@ -298,7 +309,11 @@ const renderOptionsInterface: (model: {
     type: string;
   }>;
 }) => string = createTempate(
-  'interface <#= it.optionsName #> extends IOptions, IHtmlOptions {\n'
+  `interface <#= it.optionsName #>${TYPE_PARAMS_WITH_DEFAULTS} extends Properties${TYPE_PARAMS}, IHtmlOptions {\n`
+
++ '<#? it.typeParams #>'
+    + `  dataSource?: Properties${TYPE_PARAMS}["dataSource"];\n`
++ '<#?#>'
 
 + '<#~ it.templates :template #>'
     + `  <#= template.render #>?: ${TYPE_RENDER};\n`
@@ -329,8 +344,9 @@ const renderComponent: (model: {
   renderedPropTypings?: string[];
   isPortalComponent?: boolean;
   useRequestAnimationFrameFlag?: boolean;
+  typeParams: string[] | undefined;
 }) => string = createTempate(
-  `class <#= it.className #> extends BaseComponent<<#= it.optionsName #>> {
+  `class <#= it.className #>${TYPE_PARAMS} extends BaseComponent<<#= it.optionsName #>${TYPE_PARAMS}> {
 
   public get instance(): <#= it.widgetName #> {
     return this._instance;
@@ -547,6 +563,7 @@ function generate(component: IComponent): string {
       defaultProps: defaultProps || [],
       onChangeEvents: onChangeEvents || [],
       templates: templates || [],
+      typeParams: component.optionsTypeParams?.length ? component.optionsTypeParams : undefined,
     }),
 
     renderedComponent: renderComponent({
@@ -565,6 +582,7 @@ function generate(component: IComponent): string {
       expectedChildren: component.expectedChildren,
       useRequestAnimationFrameFlag: USE_REQUEST_ANIMATION_FRAME.has(widgetName),
       isPortalComponent: PORTAL_COMPONENTS.has(widgetName),
+      typeParams: component.optionsTypeParams?.length ? component.optionsTypeParams : undefined,
     }),
 
     renderedNestedComponents: nestedComponents && nestedComponents.map(renderNestedComponent),

--- a/packages/devextreme-react-generator/src/generator.test.ts
+++ b/packages/devextreme-react-generator/src/generator.test.ts
@@ -571,6 +571,7 @@ describe('mapWidget', () => {
     nesteds: [],
     options: [],
     templates: [],
+    optionsTypeParams: [],
   };
 
   it('should rename widget', () => {

--- a/packages/devextreme-react-generator/src/generator.ts
+++ b/packages/devextreme-react-generator/src/generator.ts
@@ -228,6 +228,7 @@ export function mapWidget(
       nestedComponents: nestedOptions && nestedOptions.length > 0 ? nestedOptions : undefined,
       expectedChildren: raw.nesteds,
       propTypings: propTypings.length > 0 ? propTypings : undefined,
+      optionsTypeParams: raw.optionsTypeParams,
     },
   };
 }


### PR DESCRIPTION
## 1. `IOptions` import renamed to `Properties`

#### Before
```ts
import dxDataGrid, {
    IOptions
} from "devextreme/ui/data_grid";

interface IDataGridOptions extends IOptions, IHtmlOptions {
```

#### After
```ts
import dxDataGrid, {
    Properties
} from "devextreme/ui/data_grid";

interface IDataGridOptions extends Properties, IHtmlOptions {
```

## 2. Generic type params are generated for some widgets

#### Before
```ts
import dxDataGrid, {
    Properties
} from "devextreme/ui/data_grid";

interface IDataGridOptions extends Properties, IHtmlOptions {
```

#### After
```ts
import dxDataGrid, {
    Properties
} from "devextreme/ui/data_grid";

interface IDataGridOptions<TRowData = any, TKey = any> extends Properties<TRowData, TKey>, IHtmlOptions {
  dataSource?: Properties<TRowData, TKey>["dataSource"];
```

This extra `dataSource` field is required for proper type inference.