### PR TITLE
Fix generic components generation

### DIFF
--- a/packages/devextreme-react-generator/src/component-generator.test.ts
+++ b/packages/devextreme-react-generator/src/component-generator.test.ts
@@ -91,7 +91,7 @@ interface ICLASS_NAMEOptions<T1 = any, T2 = any> extends Properties<T1, T2>, IHt
 
 class CLASS_NAME<T1 = any, T2 = any> extends BaseComponent<ICLASS_NAMEOptions<T1, T2>> {
 
-  public get instance(): dxCLASS_NAME {
+  public get instance(): dxCLASS_NAME<T1, T2> {
     return this._instance;
   }
 

--- a/packages/devextreme-react-generator/src/component-generator.test.ts
+++ b/packages/devextreme-react-generator/src/component-generator.test.ts
@@ -89,7 +89,7 @@ interface ICLASS_NAMEOptions<T1 = any, T2 = any> extends Properties<T1, T2>, IHt
   dataSource?: Properties<T1, T2>["dataSource"];
 }
 
-class CLASS_NAME<T1, T2> extends BaseComponent<ICLASS_NAMEOptions<T1, T2>> {
+class CLASS_NAME<T1 = any, T2 = any> extends BaseComponent<ICLASS_NAMEOptions<T1, T2>> {
 
   public get instance(): dxCLASS_NAME {
     return this._instance;

--- a/packages/devextreme-react-generator/src/component-generator.ts
+++ b/packages/devextreme-react-generator/src/component-generator.ts
@@ -353,7 +353,7 @@ const renderComponent: (model: {
 }) => string = createTempate(
   `class <#= it.className #>${TYPE_PARAMS_WITH_DEFAULTS} extends BaseComponent<<#= it.optionsName #>${TYPE_PARAMS}> {
 
-  public get instance(): <#= it.widgetName #> {
+  public get instance(): <#= it.widgetName #>${TYPE_PARAMS} {
     return this._instance;
   }
 

--- a/packages/devextreme-react-generator/src/component-generator.ts
+++ b/packages/devextreme-react-generator/src/component-generator.ts
@@ -351,7 +351,7 @@ const renderComponent: (model: {
   useRequestAnimationFrameFlag?: boolean;
   typeParams: string[] | undefined;
 }) => string = createTempate(
-  `class <#= it.className #>${TYPE_PARAMS} extends BaseComponent<<#= it.optionsName #>${TYPE_PARAMS}> {
+  `class <#= it.className #>${TYPE_PARAMS_WITH_DEFAULTS} extends BaseComponent<<#= it.optionsName #>${TYPE_PARAMS}> {
 
   public get instance(): <#= it.widgetName #> {
     return this._instance;


### PR DESCRIPTION
##  1. Add defaults for generic components' classes
Make it possible to use components' classes as types without specifying type params

### Before
```ts
const ref = useRef<DataGrid<any, any>>(...); // OK
const ref = useRef<DataGrid>(...); // compilation error
```

### After

```ts
const ref = useRef<DataGrid<any, any>>(...); // OK
const ref = useRef<DataGrid>(...); // OK
```

## 2.Fix the instance property type

### Before
Generic params are lost  and `any` defaults are used instead ( `dxDataGrid` is the same as `dxDataGrid<any, any>` )

```ts
    get instance(): dxDataGrid;
```

### After

```ts
    get instance(): dxDataGrid<TRowData, TKey>;
```

## Cherry-picks
- #641