### PR TITLE
Fix templates for react 18 strict mode.

### DIFF
--- a/packages/devextreme-react/src/core/__tests__/templates-store.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/templates-store.test.tsx
@@ -32,26 +32,26 @@ describe('templates-store', () => {
     expect(callback.mock.calls.length).toBe(2);
   });
 
-  it('removes', () => {
+  it('setDeferredRemove for remove', () => {
     const templatesStore = new TemplatesStore(jest.fn());
 
     templatesStore.add('1', jest.fn());
     templatesStore.add('2', jest.fn());
 
-    templatesStore.remove('1');
+    templatesStore.setDeferredRemove('1', true);
     expect(templatesStore.renderWrappers().length).toBe(1);
 
-    templatesStore.remove('2');
+    templatesStore.setDeferredRemove('2', true);
     expect(templatesStore.renderWrappers().length).toBe(0);
   });
 
-  it('removes not existing template correctly', () => {
+  it('setDeferredRemove not existing template correctly', () => {
     const templatesStore = new TemplatesStore(jest.fn());
 
     templatesStore.add('1', jest.fn());
 
-    templatesStore.remove('2');
-    templatesStore.remove('3');
+    templatesStore.setDeferredRemove('2', true);
+    templatesStore.setDeferredRemove('3', true);
     expect(templatesStore.renderWrappers().length).toBe(1);
   });
 
@@ -64,10 +64,20 @@ describe('templates-store', () => {
 
     expect(callback.mock.calls.length).toBe(2);
 
-    templatesStore.remove('1');
-    templatesStore.remove('2');
+    templatesStore.setDeferredRemove('1', true);
+    templatesStore.setDeferredRemove('2', true);
 
     expect(callback.mock.calls.length).toBe(2);
+  });
+
+  it('toggle deferred remove shouldnt remove template (Unmount, Mount scenarion)', () => {
+    const templatesStore = new TemplatesStore(jest.fn());
+
+    templatesStore.add('1', jest.fn());
+
+    templatesStore.setDeferredRemove('1', true);
+    templatesStore.setDeferredRemove('1', false);
+    expect(templatesStore.renderWrappers().length).toBe(1);
   });
 
   it('lists renderers execution results', () => {

--- a/packages/devextreme-react/src/core/component-base.ts
+++ b/packages/devextreme-react/src/core/component-base.ts
@@ -87,8 +87,8 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
     if (this._childNode) {
       this._element.appendChild(this._childNode);
     }
-    if (!this._childNode && this._element.children.length) {
-      this._childNode = this._element.children[0];
+    if (!this._childNode && this._element.childNodes.length) {
+      this._childNode = this._element.childNodes[0];
     }
     this._updateCssClasses(null, this.props);
   }
@@ -105,7 +105,7 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
 
   public componentWillUnmount(): void {
     if (this._instance) {
-      this._childNode && this._childNode.parentNode?.removeChild(this._childNode);
+      this._childNode?.parentNode?.removeChild(this._childNode);
       events.triggerHandler(this._element, DX_REMOVE_EVENT);
       this._instance.dispose();
     }

--- a/packages/devextreme-react/src/core/dx-template.ts
+++ b/packages/devextreme-react/src/core/dx-template.ts
@@ -34,6 +34,7 @@ function createDxTemplate(
       const prevTemplateId = renderedTemplates.get(key);
 
       let templateId: string;
+
       if (prevTemplateId) {
         templateId = prevTemplateId;
       } else {
@@ -43,7 +44,6 @@ function createDxTemplate(
           renderedTemplates.set(key, templateId);
         }
       }
-
       templatesStore.add(templateId, () => {
         const props: ITemplateArgs = {
           data: data.model,
@@ -57,10 +57,13 @@ function createDxTemplate(
             content: contentProvider(props),
             container,
             onRemoved: () => {
-              templatesStore.remove(templateId);
+              templatesStore.setDeferredRemove(templateId, true);
               renderedTemplates.delete({ key1: data.model, key2: container });
             },
-            onRendered: data.onRendered,
+            onDidMount: () => {
+              templatesStore.setDeferredRemove(templateId, false);
+              data.onRendered?.();
+            },
             key: templateId,
           },
         ) as any as TemplateWrapper;

--- a/packages/devextreme-react/src/core/template-wrapper.ts
+++ b/packages/devextreme-react/src/core/template-wrapper.ts
@@ -8,7 +8,7 @@ interface ITemplateWrapperProps {
   content: any;
   container: Element;
   onRemoved: () => void;
-  onRendered?: () => void;
+  onDidMount?: () => void;
   key: string;
 }
 
@@ -43,7 +43,7 @@ class TemplateWrapper extends React.PureComponent<ITemplateWrapperProps, ITempla
 
   public componentDidMount(): void {
     this._subscribeOnRemove();
-    this.props.onRendered?.();
+    this.props.onDidMount?.();
   }
 
   public componentDidUpdate(): void {
@@ -111,7 +111,6 @@ class TemplateWrapper extends React.PureComponent<ITemplateWrapperProps, ITempla
     const removalListener = removalListenerRequired
       ? React.createElement('span', { style: removalListenerStyle, ref: this._removalListenerRef })
       : undefined;
-
     const nodeName = TableNodeNames[container.nodeName] || 'div';
 
     return ReactDOM.createPortal(

--- a/packages/devextreme-react/src/core/templates-store.ts
+++ b/packages/devextreme-react/src/core/templates-store.ts
@@ -24,15 +24,7 @@ class TemplatesStore {
     }
   }
 
-  // public addPendingRemove(templateId: string): void {
-  //   this._pendingTemplates.push(templateId);
-  // }
-
-  // public removePendingRemove(templateId: string): void {
-  //   this._pendingTemplates.splice(this._pendingTemplates.indexOf(templateId), 1);
-  // }
-
-  protected removeDefferedTemplate(): void {
+  private removeDefferedTemplate(): void {
     Object.entries(this._templates)
       .filter(([, templateInfo]) => (templateInfo.isDeferredRemove))
       .forEach(([templateId]) => {

--- a/packages/devextreme-react/src/core/templates-store.ts
+++ b/packages/devextreme-react/src/core/templates-store.ts
@@ -1,7 +1,11 @@
 import { TemplateWrapper, TemplateWrapperRenderer } from './template-wrapper';
 
+interface TemplateInfo {
+  template: TemplateWrapperRenderer;
+  isDeferredRemove: boolean;
+}
 class TemplatesStore {
-  private readonly _templates: Record<string, TemplateWrapperRenderer> = {};
+  private readonly _templates: Record<string, TemplateInfo> = {};
 
   private readonly _onTemplateAdded: () => void;
 
@@ -10,17 +14,36 @@ class TemplatesStore {
   }
 
   public add(templateId: string, templateFunc: TemplateWrapperRenderer): void {
-    this._templates[templateId] = templateFunc;
+    this._templates[templateId] = { template: templateFunc, isDeferredRemove: false };
     this._onTemplateAdded();
   }
 
-  public remove(templateId: string): void {
-    delete this._templates[templateId];
+  public setDeferredRemove(templateId: string, isDeferredRemove: boolean): void {
+    if (this._templates[templateId]) {
+      this._templates[templateId].isDeferredRemove = isDeferredRemove;
+    }
+  }
+
+  // public addPendingRemove(templateId: string): void {
+  //   this._pendingTemplates.push(templateId);
+  // }
+
+  // public removePendingRemove(templateId: string): void {
+  //   this._pendingTemplates.splice(this._pendingTemplates.indexOf(templateId), 1);
+  // }
+
+  protected removeDefferedTemplate(): void {
+    Object.entries(this._templates)
+      .filter(([, templateInfo]) => (templateInfo.isDeferredRemove))
+      .forEach(([templateId]) => {
+        delete this._templates[templateId];
+      });
   }
 
   public renderWrappers(): TemplateWrapper[] {
+    this.removeDefferedTemplate();
     return Object.getOwnPropertyNames(this._templates).map(
-      (templateId) => this._templates[templateId](),
+      (templateId) => this._templates[templateId].template(),
     );
   }
 }


### PR DESCRIPTION
Components in React 18 in strict mode can be mounted/unmounted multiple times.
For support, this behavior template doesn't remove immediately. Now TemplateWrapper mark template to remove then DOM element removed.
It's happened in the two cases: then jQueryComponent removes the element associated with a template or React component is unmounted.
In the first case, we should remove a template from a template store. It will happen for the marked template on the next template render.
In the second case, we shouldn't remove a template if the component is mounted after unmount (we remove the deferred flag). If template mount shouldn't happen we remove the template as it happened in the first case.

Replaced this._element.children to this._element.childNodes for support the <Button>text</Button> scenario.