### PR TITLE
T1106899 - Toolbar - An item's content is not updated according to the React state if it is nested in a DataGrid component instance  in React 18

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,9 @@
 {
     "extends": [
-        "devextreme/typescript"
+        "devextreme/typescript",
+        "devextreme/spell-check"
     ],
+    //"plugins": [ "spellcheck"],
     "env": {
         "browser": true,
         "node": true,
@@ -15,14 +17,46 @@
         "import/no-cycle": "warn",
         "no-param-reassign": "warn",
         "no-underscore-dangle": "warn",
-        "@typescript-eslint/no-explicit-any": "warn"
+        "@typescript-eslint/no-explicit-any": "warn",
+        "spellcheck/spell-checker": [1, {
+            "lang": "en_US",
+            "comments": false,
+            "strings": false,
+            "identifiers": true,
+            "templates": false,
+            "skipIfMatch": [ "^\\$?..$" ],
+            "skipWords": [
+               "unschedule",
+               "subscribable",
+               "renderer"
+            ]
+        }
+    ]
     },
     "overrides": [
         {
-            "files": [ "./packages/sandbox/*.ts", "./packages/sandbox/*.tsx" ],
+            "files": [ "./packages/sandbox/*.ts", "./packages/sandbox/*.tsx", "packages/devextreme-react/src/*.ts" ],
             "rules": {
-                "import/extensions": "warn"
+                "import/extensions": "warn",
+            }
+        },
+        {
+            "files": [ "packages/devextreme-react/src/*.ts" ],
+            "rules": {
+                "spellcheck/spell-checker": ["error", {
+                    "lang": "en_US",
+                    "comments": false,
+                    "strings": false,
+                    "identifiers": true,
+                    "templates": false,
+                    "skipIfMatch": [ "^\\$?..$" ],
+                    "skipWords": [
+                        "unscheduleGuards"
+                    ]
+                }
+            ]
             }
         }
     ]
 }
+

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
         "devextreme/typescript",
         "devextreme/spell-check"
     ],
-    //"plugins": [ "spellcheck"],
     "env": {
         "browser": true,
         "node": true,
@@ -28,7 +27,8 @@
             "skipWords": [
                "unschedule",
                "subscribable",
-               "renderer"
+               "renderer",
+               "rerender"
             ]
         }
     ]
@@ -38,23 +38,6 @@
             "files": [ "./packages/sandbox/*.ts", "./packages/sandbox/*.tsx", "packages/devextreme-react/src/*.ts" ],
             "rules": {
                 "import/extensions": "warn",
-            }
-        },
-        {
-            "files": [ "packages/devextreme-react/src/*.ts" ],
-            "rules": {
-                "spellcheck/spell-checker": ["error", {
-                    "lang": "en_US",
-                    "comments": false,
-                    "strings": false,
-                    "identifiers": true,
-                    "templates": false,
-                    "skipIfMatch": [ "^\\$?..$" ],
-                    "skipWords": [
-                        "unscheduleGuards"
-                    ]
-                }
-            ]
             }
         }
     ]

--- a/packages/devextreme-react/src/core/__tests__/props-updating.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/props-updating.test.tsx
@@ -617,7 +617,7 @@ describe('cfg-component option control', () => {
       beginUpdate: jest.fn(),
       endUpdate: jest.fn(),
     }, config, [], []);
-    jest.spyOn(optionsManager as any, 'setGuard');
+    jest.spyOn(optionsManager as any, 'addGuard');
     jest.spyOn(optionsManager as any, 'setValue');
     jest.spyOn(OptionsManagerModule, 'scheduleGuards');
     jest.spyOn(OptionsManagerModule, 'unscheduleGuards');
@@ -637,7 +637,7 @@ describe('cfg-component option control', () => {
     // simulate option changing in jQuery control
     optionsManager.onOptionChanged({ name: 'value', value: 2, fullName: 'value' });
     // add guards for restore value
-    expect((optionsManager as any).setGuard).toBeCalled();
+    expect((optionsManager as any).addGuard).toBeCalled();
     // but no call it
     expect((optionsManager as any).setValue).not.toBeCalled();
     // re-render container. Unschedule guards and wait template render for schedule it back

--- a/packages/devextreme-react/src/core/__tests__/props-updating.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/props-updating.test.tsx
@@ -596,7 +596,7 @@ describe('cfg-component option control', () => {
   });
 
   // T1106899
-  it.skip('apply cfg-component option value if value has changes', () => {
+  it('apply cfg-component option value if value has changes', () => {
     const optionsManager = new OptionsManagerModule.OptionsManager(
       new TemplatesManager(new TemplatesStore(() => {})),
     );

--- a/packages/devextreme-react/src/core/__tests__/props-updating.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/props-updating.test.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable max-classes-per-file */
 import { cleanup, render } from '@testing-library/react';
 import * as React from 'react';
+import * as CommonModule from 'devextreme/core/utils/common';
 import ConfigurationComponent from '../nested-option';
-import { OptionsManager } from '../options-manager';
+import * as OptionsManagerModule from '../options-manager';
 import {
   eventHandlers,
   fireOptionChange,
@@ -10,6 +11,8 @@ import {
   Widget,
   WidgetClass,
 } from './test-component';
+import TemplatesManager from '../templates-manager';
+import { TemplatesStore } from '../templates-store';
 
 jest.useFakeTimers();
 
@@ -592,6 +595,69 @@ describe('cfg-component option control', () => {
     expect(Widget.option.mock.calls[1]).toEqual(['nestedOption.b', 'const']);
   });
 
+  // T1106899
+  it.skip('apply cfg-component option value if value has changes', () => {
+    const optionsManager = new OptionsManagerModule.OptionsManager(
+      new TemplatesManager(new TemplatesStore(() => {})),
+    );
+    const config = {
+      fullName: '',
+      predefinedOptions: {},
+      initialOptions: {},
+      options: { value: 1 },
+      templates: [],
+      configs: {},
+      configCollections: {},
+    };
+    optionsManager.setInstance({
+      skipOptionsRollBack: false,
+      option: jest.fn(),
+      on: jest.fn(),
+      off: jest.fn(),
+      beginUpdate: jest.fn(),
+      endUpdate: jest.fn(),
+    }, config, [], []);
+    jest.spyOn(optionsManager as any, 'setGuard');
+    jest.spyOn(optionsManager as any, 'setValue');
+    jest.spyOn(OptionsManagerModule, 'scheduleGuards');
+    jest.spyOn(OptionsManagerModule, 'unscheduleGuards');
+    let renderTemplate;
+    jest.spyOn(CommonModule, 'deferUpdate').mockImplementation((cb) => { renderTemplate = cb; });
+    const TestContainer = (props: any) => {
+      const { value } = props;
+      return (
+        <ControlledComponent>
+          <NestedComponent a={value} b="const" />
+        </ControlledComponent>
+      );
+    };
+
+    const { rerender } = render(<TestContainer value={2} />);
+    jest.runAllTimers();
+    // simulate option changing in jQuery control
+    optionsManager.onOptionChanged({ name: 'value', value: 2, fullName: 'value' });
+    // add guards for restore value
+    expect((optionsManager as any).setGuard).toBeCalled();
+    // but no call it
+    expect((optionsManager as any).setValue).not.toBeCalled();
+    // re-render container. Unschedule guards and wait template render for schedule it back
+    rerender(<TestContainer value={2} />);
+    expect(OptionsManagerModule.scheduleGuards).not.toBeCalled();
+    expect(OptionsManagerModule.unscheduleGuards).toBeCalled();
+    expect((optionsManager as any).setValue).not.toBeCalled();
+    jest.runAllTimers();
+    // simulate Request Animation Frame for template re-render
+    renderTemplate();
+    // guards are scheduled
+    expect(OptionsManagerModule.scheduleGuards).toBeCalled();
+    const updatedConfig = { ...config, options: { value: 2 } };
+    // value changed and options manager set value and remove scheduled guard
+    optionsManager.update(updatedConfig);
+    expect((optionsManager as any).setValue).toBeCalled();
+    jest.runAllTimers();
+    expect((optionsManager as any).setValue).toHaveBeenCalledTimes(1);
+  });
+
   it('apply cfg-component option change if value really change', () => {
     const TestContainer = (props: any) => {
       const { value } = props;
@@ -805,7 +871,8 @@ describe('onXXXChange', () => {
 
     beforeAll(() => {
       jest.spyOn(
-        OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },
+        OptionsManagerModule.OptionsManager.prototype as
+        OptionsManagerModule.OptionsManager & { isOptionSubscribable: () => boolean; },
         'isOptionSubscribable',
       )
         .mockImplementation(() => true);
@@ -1040,7 +1107,8 @@ describe('onXXXChange', () => {
   describe('non-subscribable options', () => {
     beforeAll(() => {
       jest.spyOn(
-        OptionsManager.prototype as OptionsManager & { isOptionSubscribable: () => boolean; },
+        OptionsManagerModule.OptionsManager.prototype as
+        OptionsManagerModule.OptionsManager & { isOptionSubscribable: () => boolean; },
         'isOptionSubscribable',
       )
         .mockImplementation(() => false);
@@ -1080,7 +1148,8 @@ describe('onXXXChange', () => {
   describe('independent events', () => {
     beforeAll(() => {
       jest.spyOn(
-        OptionsManager.prototype as OptionsManager & { isIndependentEvent: () => boolean; },
+        OptionsManagerModule.OptionsManager.prototype as
+        OptionsManagerModule.OptionsManager & { isIndependentEvent: () => boolean; },
         'isIndependentEvent',
       )
         .mockImplementation(() => true);
@@ -1136,7 +1205,8 @@ describe('onXXXChange', () => {
   describe('dependent events', () => {
     beforeAll(() => {
       jest.spyOn(
-        OptionsManager.prototype as OptionsManager & { isIndependentEvent: () => boolean; },
+        OptionsManagerModule.OptionsManager.prototype as
+        OptionsManagerModule.OptionsManager & { isIndependentEvent: () => boolean; },
         'isIndependentEvent',
       )
         .mockImplementation(() => false);

--- a/packages/devextreme-react/src/core/__tests__/templates-renderer.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/templates-renderer.test.tsx
@@ -91,7 +91,7 @@ jest.mock('devextreme/core/utils/common', () => ({
   });
 });
 
-fdescribe('option update', () => {
+describe('option update', () => {
   it('should call forceUpdateCallback and reset "updateScheduled" after forceUpdateCallback', async () => {
     const ref = React.createRef<TemplatesRenderer>();
     const templatesStore = new TemplatesStore(() => { });
@@ -101,19 +101,17 @@ fdescribe('option update', () => {
     });
 
     render(<TemplatesRenderer templatesStore={templatesStore} ref={ref} />);
-
     const current = ref.current!;
-    const actualForceUpdateCallback = current.forceUpdateCallback;
-    const spyForceUpdateCallback = jest.spyOn(current, 'forceUpdateCallback').mockImplementation(() => {
+    const onRendered = jest.fn();
+    const spyForceUpdateCallback = jest.spyOn(current, 'forceUpdate').mockImplementation((cb) => {
       expect((current as any).updateScheduled).toEqual(true);
-
-      actualForceUpdateCallback();
+      expect(onRendered).not.toHaveBeenCalled();
+      cb();
+      expect(onRendered).toHaveBeenCalled();
 
       expect((current as any).updateScheduled).toEqual(false);
     });
-
-    current.scheduleUpdate(true);
-
+    current.scheduleUpdate(true, onRendered);
     expect(spyForceUpdateCallback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/devextreme-react/src/core/component-base.ts
+++ b/packages/devextreme-react/src/core/component-base.ts
@@ -4,15 +4,16 @@ import { createPortal } from 'react-dom';
 
 import { OptionsManager, scheduleGuards, unscheduleGuards } from './options-manager';
 import { ITemplateMeta } from './template';
-import TemplatesManager from './templates-manager';
-import { TemplatesRenderer } from './templates-renderer';
-import { TemplatesStore } from './templates-store';
 import { elementPropNames, getClassName } from './widget-config';
 
 import { IConfigNode } from './configuration/config-node';
 import { IExpectedChild } from './configuration/react/element';
 import { buildConfigTree } from './configuration/react/tree';
 import { isIE } from './configuration/utils';
+
+import type { TemplatesRenderer } from './templates-renderer';
+import type { TemplatesStore } from './templates-store';
+import type TemplatesManager from './templates-manager';
 
 const DX_REMOVE_EVENT = 'dxremove';
 

--- a/packages/devextreme-react/src/core/component-base.ts
+++ b/packages/devextreme-react/src/core/component-base.ts
@@ -2,7 +2,7 @@ import * as events from 'devextreme/events';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 
-import { OptionsManager } from './options-manager';
+import { OptionsManager, scheduleGuards, unscheduleGuards } from './options-manager';
 import { ITemplateMeta } from './template';
 import TemplatesManager from './templates-manager';
 import { TemplatesRenderer } from './templates-renderer';
@@ -94,12 +94,12 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
 
   public componentDidUpdate(prevProps: P): void {
     this._updateCssClasses(prevProps, this.props);
-
     const config = this._getConfig();
     this._optionsManager.update(config);
     if (this._templatesRendererRef) {
-      this._templatesRendererRef.scheduleUpdate(this.useDeferUpdateForTemplates);
+      this._templatesRendererRef.scheduleUpdate(this.useDeferUpdateForTemplates, scheduleGuards);
     }
+    unscheduleGuards();
   }
 
   public componentWillUnmount(): void {

--- a/packages/devextreme-react/src/core/component-base.ts
+++ b/packages/devextreme-react/src/core/component-base.ts
@@ -2,6 +2,10 @@ import * as events from 'devextreme/events';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 
+import TemplatesManager from './templates-manager';
+import { TemplatesRenderer } from './templates-renderer';
+import { TemplatesStore } from './templates-store';
+
 import { OptionsManager, scheduleGuards, unscheduleGuards } from './options-manager';
 import { ITemplateMeta } from './template';
 import { elementPropNames, getClassName } from './widget-config';
@@ -10,10 +14,6 @@ import { IConfigNode } from './configuration/config-node';
 import { IExpectedChild } from './configuration/react/element';
 import { buildConfigTree } from './configuration/react/tree';
 import { isIE } from './configuration/utils';
-
-import type { TemplatesRenderer } from './templates-renderer';
-import type { TemplatesStore } from './templates-store';
-import type TemplatesManager from './templates-manager';
 
 const DX_REMOVE_EVENT = 'dxremove';
 

--- a/packages/devextreme-react/src/core/options-manager.ts
+++ b/packages/devextreme-react/src/core/options-manager.ts
@@ -8,14 +8,14 @@ import type TemplatesManager from './templates-manager';
 import type { IConfigNode } from './configuration/config-node';
 
 const optionsManagers = new Set<OptionsManager>();
-let guadtTimeoutHandler = -1;
+let guardTimeoutHandler = -1;
 
 export function unscheduleGuards(): void {
-  clearTimeout(guadtTimeoutHandler);
+  clearTimeout(guardTimeoutHandler);
 }
 export function scheduleGuards(): void {
   unscheduleGuards();
-  guadtTimeoutHandler = window.setTimeout(() => {
+  guardTimeoutHandler = window.setTimeout(() => {
     optionsManagers.forEach((optionManager) => optionManager.execGuards());
   });
 }

--- a/packages/devextreme-react/src/core/options-manager.ts
+++ b/packages/devextreme-react/src/core/options-manager.ts
@@ -1,23 +1,27 @@
 /* eslint-disable no-restricted-globals */
-import TemplatesManager from './templates-manager';
-
 import { getChanges } from './configuration/comparer';
-import { IConfigNode } from './configuration/config-node';
 import { buildConfig, findValue, ValueType } from './configuration/tree';
 import { mergeNameParts, shallowEquals } from './configuration/utils';
 import { capitalizeFirstLetter } from './helpers';
 
-const optionsManagers = new Set<OptionsManager>();
+import type TemplatesManager from './templates-manager';
+import type { IConfigNode } from './configuration/config-node';
 
-export function scheduleGuards(): void {
-  optionsManagers.forEach((optionManager) => optionManager.scheduleGuards());
-}
+const optionsManagers = new Set<OptionsManager>();
+let guadtTimeoutHandler = -1;
+
 export function unscheduleGuards(): void {
-  optionsManagers.forEach((optionManager) => optionManager.unscheduleGuards());
+  clearTimeout(guadtTimeoutHandler);
+}
+export function scheduleGuards(): void {
+  unscheduleGuards();
+  guadtTimeoutHandler = window.setTimeout(() => {
+    optionsManagers.forEach((optionManager) => optionManager.execGuards());
+  });
 }
 
 class OptionsManager {
-  private readonly guards: Record<string, { handler: ()=> void, guardId?: number }> = {};
+  private readonly guards: Record<string, ()=> void> = {};
 
   private templatesManager: TemplatesManager;
 
@@ -73,7 +77,7 @@ class OptionsManager {
   }
 
   public update(config: IConfigNode): void {
-    const changedOptions:Array<[string, any]> = [];
+    const changedOptions:Array<[string, unknown]> = [];
     const optionChangedHandler = ({ value, fullName }) => {
       changedOptions.push([fullName, value]);
     };
@@ -141,7 +145,7 @@ class OptionsManager {
     if (value instanceof Array && type === ValueType.Array) {
       for (let i = 0; i < value.length; i += 1) {
         if (value[i] !== (e.value as Array<unknown>)?.[i]) {
-          this.setGuard(e.fullName, value);
+          this.addGuard(e.fullName, value);
           return;
         }
       }
@@ -150,7 +154,7 @@ class OptionsManager {
         if (value[key] === (e.value as Record<string, unknown>)?.[key]) {
           return;
         }
-        this.setGuard(mergeNameParts(e.fullName, key), value[key]);
+        this.addGuard(mergeNameParts(e.fullName, key), value[key]);
       });
     } else {
       const valuesAreEqual = value === e.value;
@@ -163,35 +167,15 @@ class OptionsManager {
         return;
       }
 
-      this.setGuard(e.fullName, value);
+      this.addGuard(e.fullName, value);
     }
   }
 
   public dispose(): void {
     optionsManagers.delete(this);
     Object.keys(this.guards).forEach((optionName) => {
-      window.clearTimeout(this.guards[optionName].guardId);
       delete this.guards[optionName];
     });
-  }
-
-  public unscheduleGuards(): void {
-    Object.values(this.guards)
-      .forEach((guardInfo) => {
-        window.clearTimeout(guardInfo.guardId);
-      });
-  }
-
-  public scheduleGuards() {
-    Object.values(this.guards)
-      .forEach((guardInfo) => {
-        window.clearTimeout(guardInfo.guardId);
-        // eslint-disable-next-line no-param-reassign
-        guardInfo.guardId = window.setTimeout(() => {
-          window.clearTimeout(guardInfo.guardId);
-          guardInfo.handler();
-        });
-      });
   }
 
   private isOptionSubscribable(optionName: string): boolean {
@@ -243,7 +227,7 @@ class OptionsManager {
     return value;
   }
 
-  private setGuard(optionName: string, optionValue: unknown): void {
+  private addGuard(optionName: string, optionValue: unknown): void {
     if (this.guards[optionName] !== undefined) {
       return;
     }
@@ -251,7 +235,13 @@ class OptionsManager {
       this.setValue(optionName, optionValue);
       delete this.guards[optionName];
     };
-    this.guards[optionName] = { handler, guardId: window.setTimeout(() => { handler(); }) };
+    this.guards[optionName] = handler;
+    scheduleGuards();
+  }
+
+  public execGuards(): void {
+    Object.values(this.guards)
+      .forEach((handler) => handler());
   }
 
   private resetOption(name: string) {
@@ -260,7 +250,6 @@ class OptionsManager {
 
   private setValue(name: string, value: unknown) {
     if (this.guards[name]) {
-      window.clearTimeout(this.guards[name].guardId);
       delete this.guards[name];
     }
 

--- a/packages/devextreme-react/src/core/templates-renderer.tsx
+++ b/packages/devextreme-react/src/core/templates-renderer.tsx
@@ -6,7 +6,6 @@ import { TemplatesStore } from './templates-store';
 
 class TemplatesRenderer extends React.PureComponent<{
   templatesStore: TemplatesStore;
-  children?: React.ReactNode;
 }> {
   private updateScheduled = false;
 

--- a/packages/devextreme-react/src/core/templates-renderer.tsx
+++ b/packages/devextreme-react/src/core/templates-renderer.tsx
@@ -4,8 +4,12 @@ import * as React from 'react';
 
 import { TemplatesStore } from './templates-store';
 
-class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesStore }> {
+class TemplatesRenderer extends React.PureComponent<{
+  templatesStore: TemplatesStore;
+  children?: React.ReactNode;
+}> {
   private updateScheduled = false;
+
   private mounted = false;
 
   componentDidMount(): void {
@@ -16,11 +20,7 @@ class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesS
     this.mounted = false;
   }
 
-  forceUpdateCallback = () => {
-    this.updateScheduled = false;
-  }
-
-  public scheduleUpdate(useDeferUpdate: boolean): void {
+  public scheduleUpdate(useDeferUpdate: boolean, onRendered?: () => void): void {
     if (this.updateScheduled) {
       return;
     }
@@ -30,7 +30,10 @@ class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesS
     const updateFunc = useDeferUpdate ? deferUpdate : requestAnimationFrame;
     updateFunc(() => {
       if (this.mounted) {
-        this.forceUpdate(this.forceUpdateCallback);
+        this.forceUpdate(() => {
+          this.updateScheduled = false;
+          onRendered?.();
+        });
       }
       this.updateScheduled = false;
     });


### PR DESCRIPTION
In new react 18 guards call early then switch is rendered. Move scedule guard timeout's after switch is rendered.