### PR TITLE
T1106899 - Toolbar - An item's content is not updated according to the React state if it is nested in a DataGrid component instance  in React 18 (#751)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "extends": [
-        "devextreme/typescript"
+        "devextreme/typescript",
+        "devextreme/spell-check"
     ],
     "env": {
         "browser": true,
@@ -15,14 +16,30 @@
         "import/no-cycle": "warn",
         "no-param-reassign": "warn",
         "no-underscore-dangle": "warn",
-        "@typescript-eslint/no-explicit-any": "warn"
+        "@typescript-eslint/no-explicit-any": "warn",
+        "spellcheck/spell-checker": [1, {
+            "lang": "en_US",
+            "comments": false,
+            "strings": false,
+            "identifiers": true,
+            "templates": false,
+            "skipIfMatch": [ "^\\$?..$" ],
+            "skipWords": [
+               "unschedule",
+               "subscribable",
+               "renderer",
+               "rerender"
+            ]
+        }
+    ]
     },
     "overrides": [
         {
-            "files": [ "./packages/sandbox/*.ts", "./packages/sandbox/*.tsx" ],
+            "files": [ "./packages/sandbox/*.ts", "./packages/sandbox/*.tsx", "packages/devextreme-react/src/*.ts" ],
             "rules": {
-                "import/extensions": "warn"
+                "import/extensions": "warn",
             }
         }
     ]
 }
+

--- a/packages/devextreme-react/src/core/__tests__/templates-renderer.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/templates-renderer.test.tsx
@@ -90,7 +90,7 @@ jest.mock('devextreme/core/utils/common', () => ({
   });
 });
 
-fdescribe('option update', () => {
+describe('option update', () => {
   it('should call forceUpdateCallback and reset "updateScheduled" after forceUpdateCallback', async () => {
     const ref = React.createRef<TemplatesRenderer>();
     const templatesStore = new TemplatesStore(() => { });
@@ -100,19 +100,17 @@ fdescribe('option update', () => {
     });
 
     render(<TemplatesRenderer templatesStore={templatesStore} ref={ref} />);
-
     const current = ref.current!;
-    const actualForceUpdateCallback = current.forceUpdateCallback;
-    const spyForceUpdateCallback = jest.spyOn(current, 'forceUpdateCallback').mockImplementation(() => {
+    const onRendered = jest.fn();
+    const spyForceUpdateCallback = jest.spyOn(current, 'forceUpdate').mockImplementation((cb) => {
       expect((current as any).updateScheduled).toEqual(true);
-
-      actualForceUpdateCallback();
+      expect(onRendered).not.toHaveBeenCalled();
+      cb();
+      expect(onRendered).toHaveBeenCalled();
 
       expect((current as any).updateScheduled).toEqual(false);
     });
-
-    current.scheduleUpdate(true);
-
+    current.scheduleUpdate(true, onRendered);
     expect(spyForceUpdateCallback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/devextreme-react/src/core/component-base.ts
+++ b/packages/devextreme-react/src/core/component-base.ts
@@ -2,11 +2,12 @@ import * as events from 'devextreme/events';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 
-import { OptionsManager } from './options-manager';
-import { ITemplateMeta } from './template';
 import TemplatesManager from './templates-manager';
 import { TemplatesRenderer } from './templates-renderer';
 import { TemplatesStore } from './templates-store';
+
+import { OptionsManager, scheduleGuards, unscheduleGuards } from './options-manager';
+import { ITemplateMeta } from './template';
 import { elementPropNames, getClassName } from './widget-config';
 
 import { IConfigNode } from './configuration/config-node';
@@ -94,12 +95,12 @@ abstract class ComponentBase<P extends IHtmlOptions> extends React.PureComponent
 
   public componentDidUpdate(prevProps: P): void {
     this._updateCssClasses(prevProps, this.props);
-
     const config = this._getConfig();
     this._optionsManager.update(config);
     if (this._templatesRendererRef) {
-      this._templatesRendererRef.scheduleUpdate(this.useDeferUpdateForTemplates);
+      this._templatesRendererRef.scheduleUpdate(this.useDeferUpdateForTemplates, scheduleGuards);
     }
+    unscheduleGuards();
   }
 
   public componentWillUnmount(): void {

--- a/packages/devextreme-react/src/core/templates-renderer.tsx
+++ b/packages/devextreme-react/src/core/templates-renderer.tsx
@@ -4,8 +4,11 @@ import * as React from 'react';
 
 import { TemplatesStore } from './templates-store';
 
-class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesStore }> {
+class TemplatesRenderer extends React.PureComponent<{
+  templatesStore: TemplatesStore;
+}> {
   private updateScheduled = false;
+
   private mounted = false;
 
   componentDidMount(): void {
@@ -16,11 +19,7 @@ class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesS
     this.mounted = false;
   }
 
-  forceUpdateCallback = () => {
-    this.updateScheduled = false;
-  }
-
-  public scheduleUpdate(useDeferUpdate: boolean): void {
+  public scheduleUpdate(useDeferUpdate: boolean, onRendered?: () => void): void {
     if (this.updateScheduled) {
       return;
     }
@@ -30,7 +29,10 @@ class TemplatesRenderer extends React.PureComponent<{ templatesStore: TemplatesS
     const updateFunc = useDeferUpdate ? deferUpdate : requestAnimationFrame;
     updateFunc(() => {
       if (this.mounted) {
-        this.forceUpdate(this.forceUpdateCallback);
+        this.forceUpdate(() => {
+          this.updateScheduled = false;
+          onRendered?.();
+        });
       }
       this.updateScheduled = false;
     });


### PR DESCRIPTION
* Fix T1106899
In new react 18 guards call early then a switch is rendered. Move schedule guard timeout after the switch is rendered.