### PR TITLE
Add TS type for deferUpdate mock

### DIFF
--- a/packages/devextreme-react/src/core/__tests__/templates-renderer.test.tsx
+++ b/packages/devextreme-react/src/core/__tests__/templates-renderer.test.tsx
@@ -96,7 +96,7 @@ describe('option update', () => {
     const ref = React.createRef<TemplatesRenderer>();
     const templatesStore = new TemplatesStore(() => { });
 
-    deferUpdate.mockImplementation((func, _) => {
+    (deferUpdate as jest.Mock).mockImplementation((func, _) => {
       func();
     });
 


### PR DESCRIPTION
After the changes were made in the main devextreme repo https://github.com/DevExpress/DevExtreme/commit/e4447cf2041ba82d008b71d650557966ae049bec, https://github.com/DevExpress/DevExtreme/commit/af1cbaef09a92487f9665a90b0a17c6efc2827de, a test in the devextreme-react repo began to fail with an error:
`TS2339: Property 'mockImplementation' does not exist on type '<T>(func: () => T, deferred?: DeferredObj<T> | undefined) => T | DeferredObj<T> | Promise<T>'.` 
This PR adds a missing type.