### PR TITLE
Fix Options type generation

### DIFF
--- a/packages/devextreme-react-generator/package.json
+++ b/packages/devextreme-react-generator/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Developer Express Inc.",
   "name": "devextreme-react-generator",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "DevExtreme React UI and Visualization Components",
   "repository": {
     "type": "git",

--- a/packages/devextreme-react-generator/src/component-generator.test.ts
+++ b/packages/devextreme-react-generator/src/component-generator.test.ts
@@ -9,8 +9,7 @@ import dxCLASS_NAME, {
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -42,10 +41,13 @@ it('generates extension component', () => {
   // #region EXPECTED
   const EXPECTED = `
 import dxCLASS_NAME, {
-    Properties as ICLASS_NAMEOptions
+    Properties
 } from "DX/WIDGET/PATH";
 
 import { ExtensionComponent as BaseComponent } from "EXTENSION_COMPONENT_PATH";
+import { IHtmlOptions } from "BASE_COMPONENT_PATH";
+
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -457,8 +459,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -571,8 +572,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -639,8 +639,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -724,8 +723,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -800,8 +798,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -873,8 +870,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -966,8 +962,7 @@ import dxCLASS_NAME, {
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1014,8 +1009,7 @@ import dxCLASS_NAME, {
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1069,8 +1063,7 @@ import dxCLASS_NAME, {
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1120,8 +1113,7 @@ import dxCLASS_NAME, {
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1171,8 +1163,7 @@ import dxCLASS_NAME, {
 import * as PropTypes from "prop-types";
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1238,8 +1229,7 @@ import dxCLASS_NAME, {
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1286,8 +1276,7 @@ import dxCLASS_NAME, {
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 import NestedOption from "CONFIG_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1370,8 +1359,7 @@ type ICLASS_NAMEOptionsNarrowedEvents = {
   onSomethingHappened?: ((e: SomethingHappenedEvent) => void);
 }
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<ReplaceFieldTypes<Properties, ICLASS_NAMEOptionsNarrowedEvents> & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<ReplaceFieldTypes<Properties, ICLASS_NAMEOptionsNarrowedEvents> & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 
@@ -1408,8 +1396,7 @@ import dxCLASS_NAME, {
 
 import { Component as BaseComponent, IHtmlOptions } from "BASE_COMPONENT_PATH";
 
-type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions & {
-}>
+type ICLASS_NAMEOptions = React.PropsWithChildren<Properties & IHtmlOptions>
 
 class CLASS_NAME extends BaseComponent<React.PropsWithChildren<ICLASS_NAMEOptions>> {
 


### PR DESCRIPTION
## Fixes extension components
Adds `IHtmlOptions` to extension components options which is required for `React.PropsWithChildren`

### Diff

```diff
import dxValidator, {
-    Properties as IValidatorOptions
+    Properties
} from "devextreme/ui/validator";

 import * as PropTypes from "prop-types";
 import { ExtensionComponent as BaseComponent } from "./core/extension-component";
+import { IHtmlOptions } from "./core/component";
 import NestedOption from "./core/nested-option";

+type IValidatorOptions = React.PropsWithChildren<Properties & IHtmlOptions>
```

### Affects
- validator.ts

## Beautifies other component options
Removes unnecessary empty object from components options without extra fields

### Before

```ts
type IBulletOptions = React.PropsWithChildren<ReplaceFieldTypes<Properties, IBulletOptionsNarrowedEvents> & IHtmlOptions & {
}>
```

### After

```ts
type IBulletOptions = React.PropsWithChildren<ReplaceFieldTypes<Properties, IBulletOptionsNarrowedEvents> & IHtmlOptions>
```
### Affects
-  bullet.ts
- defer-rendering.ts
- file-manager.ts
- load-indicator.ts
- pivot-grid-field-chooser.ts
- pivot-grid.ts
- scroll-view.ts
- sparkline.ts
- speed-dial-action.ts
- validation-group.ts
- validator.ts